### PR TITLE
docs: correct Talos MSR guidance (Talos ships no msr module)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Driver support comes from qmlib (see its
 [DRIVERS.md](https://github.com/ulissesf/qmassa/blob/main/qmlib/DRIVERS.md) for
 the authoritative, per-kernel-version matrix):
 
-| Driver   | GPUs                              | Engines | Memory | Frequency | Power | Temps / Fans |
-| -------- | --------------------------------- | :-----: | :----: | :-------: | :---: | :----------: |
-| `i915`   | Older Intel (Gen ≤ 12, e.g. UHD/Iris Xe) | ✅ perf PMU | ✅ | ✅ | ✅ iGPU via PMU/MSR, dGPU via hwmon | ✅ |
-| `xe`     | Newer Intel (Xe, Arc, Lunar Lake+) | ✅ perf PMU | ✅ | ✅ | ✅ iGPU via PMU/MSR, dGPU via hwmon | ✅ |
-| `amdgpu` | AMD integrated and discrete       | ✅ sysfs | ✅ | ✅ | ✅ dGPU via hwmon | ✅ dGPU via hwmon |
+| Driver   | GPUs                                     |   Engines   | Memory | Frequency |                Power                |   Temps / Fans    |
+| -------- | ---------------------------------------- | :---------: | :----: | :-------: | :---------------------------------: | :---------------: |
+| `i915`   | Older Intel (Gen ≤ 12, e.g. UHD/Iris Xe) | ✅ perf PMU |   ✅   |    ✅     | ✅ iGPU via PMU/MSR, dGPU via hwmon |        ✅         |
+| `xe`     | Newer Intel (Xe, Arc, Lunar Lake+)       | ✅ perf PMU |   ✅   |    ✅     | ✅ iGPU via PMU/MSR, dGPU via hwmon |        ✅         |
+| `amdgpu` | AMD integrated and discrete              |  ✅ sysfs   |   ✅   |    ✅     |          ✅ dGPU via hwmon          | ✅ dGPU via hwmon |
 
 The exporter reads engine utilization from the perf PMU on Intel (`i915`/`xe`)
 and from sysfs on AMD. This assumes a current kernel — in particular **Linux
@@ -29,15 +29,15 @@ supported.
 All series are gauges prefixed `drm_`, with a `device` label (the PCI slot, e.g.
 `0000:03:00.0`) identifying the GPU:
 
-| Metric | Extra labels | Meaning |
-| ------ | ------------ | ------- |
-| `drm_info` | `pci_id`, `vendor`, `model`, `revision`, `driver`, `type`, `dev_node` | Constant `1`; carries the GPU's static identity for PromQL joins |
-| `drm_memory_used_bytes` / `drm_memory_total_bytes` | `pool` (`smem`/`vram`) | Memory usage by pool (VRAM only on discrete GPUs) |
-| `drm_engine_utilization_ratio` | `engine` | Per-engine busy fraction, `0.0`–`1.0` |
-| `drm_frequency_hertz` | `domain`, `kind` (`actual`/`max`) | Clock frequency |
-| `drm_power_watts` | `domain` (`gpu`/`package`) | Power draw |
-| `drm_temperature_celsius` | `sensor` | Temperature |
-| `drm_fan_speed_rpm` | `fan` | Fan speed |
+| Metric                                             | Extra labels                                                          | Meaning                                                          |
+| -------------------------------------------------- | --------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `drm_info`                                         | `pci_id`, `vendor`, `model`, `revision`, `driver`, `type`, `dev_node` | Constant `1`; carries the GPU's static identity for PromQL joins |
+| `drm_memory_used_bytes` / `drm_memory_total_bytes` | `pool` (`smem`/`vram`)                                                | Memory usage by pool (VRAM only on discrete GPUs)                |
+| `drm_engine_utilization_ratio`                     | `engine`                                                              | Per-engine busy fraction, `0.0`–`1.0`                            |
+| `drm_frequency_hertz`                              | `domain`, `kind` (`actual`/`max`)                                     | Clock frequency                                                  |
+| `drm_power_watts`                                  | `domain` (`gpu`/`package`)                                            | Power draw                                                       |
+| `drm_temperature_celsius`                          | `sensor`                                                              | Temperature                                                      |
+| `drm_fan_speed_rpm`                                | `fan`                                                                 | Fan speed                                                        |
 
 A section is simply omitted for a device/driver that does not expose it (e.g.
 no `drm_power_watts` where power is unavailable). `GET /health` returns `OK` for
@@ -45,7 +45,7 @@ liveness probes; metrics are served on `GET /metrics` (and any other path).
 
 Metrics are instrumented on the OpenTelemetry API and exposed through
 `opentelemetry-prometheus` + the `prometheus` crate — the same stack as the
-org's other Rust project (kopiur). Set `OTEL_EXPORTER_OTLP_ENDPOINT` to *also*
+org's other Rust project (kopiur). Set `OTEL_EXPORTER_OTLP_ENDPOINT` to _also_
 push metrics over OTLP/gRPC (plaintext, like kopiur); leave it unset for
 Prometheus pull only, in which case no async runtime is created (the OTLP path
 spins up a small tokio runtime just for the tonic channel when enabled). As a
@@ -57,13 +57,13 @@ the `drm_*` queries the bundled dashboard uses.
 
 Every flag has a `DRM_EXPORTER_*` environment variable equivalent:
 
-| Flag | Env | Default | Description |
-| ---- | --- | ------- | ----------- |
-| `-a`, `--address` | `DRM_EXPORTER_ADDRESS` | `0.0.0.0` | Metrics HTTP bind address |
-| `-p`, `--port` | `DRM_EXPORTER_PORT` | `9090` | Metrics HTTP port |
-| `-i`, `--interval-seconds` | `DRM_EXPORTER_INTERVAL_SECONDS` | `5` | Seconds between GPU stat refreshes |
-| `-d`, `--devices` | `DRM_EXPORTER_DEVICES` | _(all)_ | Comma-separated PCI slots to export |
-| `--driver-option` | — | _(driver defaults)_ | Advanced qmlib `driver=key=value` options (repeatable) |
+| Flag                       | Env                             | Default             | Description                                            |
+| -------------------------- | ------------------------------- | ------------------- | ------------------------------------------------------ |
+| `-a`, `--address`          | `DRM_EXPORTER_ADDRESS`          | `0.0.0.0`           | Metrics HTTP bind address                              |
+| `-p`, `--port`             | `DRM_EXPORTER_PORT`             | `9090`              | Metrics HTTP port                                      |
+| `-i`, `--interval-seconds` | `DRM_EXPORTER_INTERVAL_SECONDS` | `5`                 | Seconds between GPU stat refreshes                     |
+| `-d`, `--devices`          | `DRM_EXPORTER_DEVICES`          | _(all)_             | Comma-separated PCI slots to export                    |
+| `--driver-option`          | —                               | _(driver defaults)_ | Advanced qmlib `driver=key=value` options (repeatable) |
 
 `RUST_LOG` controls log verbosity (default `info`); qmlib's own logs are bridged
 into the same output.
@@ -114,7 +114,7 @@ Reading GPU telemetry requires host access:
 - **`/dev/dri`** — discover and read GPUs.
 - **`/sys`** (read-only) — frequency, memory, AMD engines, hwmon (temp/fan/power).
 - **`CAP_PERFMON`** — Intel engine utilization, and the preferred RAPL power path, via the perf PMU.
-- **`/dev/cpu`** (read-only) + **`CAP_SYS_RAWIO`** — per-CPU MSRs, for Intel **iGPU package temperature** and the RAPL power fallback. **Requires the host `msr` kernel module** — autoloaded on most distros, but on Talos add it via machine config (`machine.kernel.modules: [{name: msr}]`); without it, Intel iGPU temperature is unavailable.
+- **`/dev/cpu`** (read-only) + **`CAP_SYS_RAWIO`** — per-CPU MSRs, for Intel **iGPU package temperature** and the RAPL power _fallback_. **Requires the host `msr` kernel module** (autoloaded on most distros). **Talos does not ship `msr`** and treats userspace MSR access as a security risk ([siderolabs/extensions#620](https://github.com/siderolabs/extensions/issues/620)), so on Talos drop this device and capability — set `hostAccess.devCpu: ""` and remove `SYS_RAWIO`. The exporter then runs on the perf-PMU path (engine utilization, memory, frequency, and power all still work); only Intel iGPU package temperature is unavailable.
 
 AMD GPUs and all sysfs-based stats need none of these. The Helm chart's default
 runs as root with just those two capabilities (not privileged, read-only root

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -107,7 +107,7 @@ Kubernetes: `>=1.25.0-0`
 | envFrom | list | `[]` | Sources of environment variables for the container (templated). |
 | extraEnv | list | `[]` | Extra environment variables for the container, as a raw list (templated). |
 | fullnameOverride | string | `""` | Override the generated name used for every resource's `metadata.name` (the chart "fullname"). |
-| hostAccess.devCpu | string | `"/dev/cpu"` | Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module (Talos: load it via machine config). Harmless (unused) on AMD GPUs; set to "" to skip. |
+| hostAccess.devCpu | string | `"/dev/cpu"` | Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module — autoloaded on most distros, but Talos does not ship it (siderolabs/extensions#620), so set this to "" on Talos (iGPU package temperature is then unavailable; engine/memory/frequency/power still work). Harmless (unused) on AMD GPUs; set to "" to skip. |
 | hostAccess.devDri | string | `"/dev/dri"` | Host path for the DRM device nodes, mounted read-write; required to discover and read GPUs. |
 | hostAccess.hostNetwork | bool | `false` | Use host networking (scrape via the node IP:port instead of through the Service). |
 | hostAccess.sys | string | `"/sys"` | Host path for sysfs, mounted read-only; required for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats. |
@@ -143,7 +143,7 @@ Kubernetes: `>=1.25.0-0`
 | priorityClassName | string | `""` | PriorityClass for the pod (templated); empty uses the cluster default. |
 | readinessProbe | object | `{"httpGet":{"path":"/health","port":"metrics"},"initialDelaySeconds":2,"periodSeconds":10}` | Readiness probe. |
 | resources | object | `{}` | Exporter container resource requests/limits. |
-| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["PERFMON","SYS_RAWIO"],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | Exporter container securityContext. Drops ALL capabilities, then adds only what GPU telemetry needs: PERFMON (Intel i915/xe engine utilization via the perf PMU) and SYS_RAWIO (Intel iGPU package temperature + the RAPL power fallback via /dev/cpu/*/msr, which needs the host msr kernel module). AMD and all sysfs-based stats need neither. Read-only root filesystem, no privilege escalation, not privileged. |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["PERFMON","SYS_RAWIO"],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | Exporter container securityContext. Drops ALL capabilities, then adds only what GPU telemetry needs: PERFMON (Intel i915/xe engine utilization via the perf PMU) and SYS_RAWIO (Intel iGPU package temperature + the RAPL power fallback via /dev/cpu/*/msr, which needs the host msr kernel module — absent on Talos, so drop SYS_RAWIO there). AMD and all sysfs-based stats need neither. Read-only root filesystem, no privilege escalation, not privileged. |
 | service.annotations | object | `{}` | Service annotations. |
 | service.type | string | `"ClusterIP"` | Service type. |
 | serviceAccount.annotations | object | `{}` | ServiceAccount annotations. |

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -82,11 +82,11 @@
       "type": "object"
     },
     "hostAccess": {
-      "description": "Host access. Reading GPU stats requires the node's DRM device nodes and sysfs;\nIntel iGPU package temperature (and the RAPL power fallback) additionally need\nthe per-CPU MSR device nodes, which require the host `msr` kernel module. Set a\npath to \"\" to skip mounting it.",
+      "description": "Host access. Reading GPU stats requires the node's DRM device nodes and sysfs;\nIntel iGPU package temperature (and the RAPL power fallback) additionally need\nthe per-CPU MSR device nodes, which require the host `msr` kernel module (not\nshipped by Talos — see the devCpu note below). Set a path to \"\" to skip mounting it.",
       "properties": {
         "devCpu": {
           "default": "/dev/cpu",
-          "description": "Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module (Talos: load it via machine config). Harmless (unused) on AMD GPUs; set to \"\" to skip.",
+          "description": "Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module — autoloaded on most distros, but Talos does not ship it (siderolabs/extensions#620), so set this to \"\" on Talos (iGPU package temperature is then unavailable; engine/memory/frequency/power still work). Harmless (unused) on AMD GPUs; set to \"\" to skip.",
           "title": "devCpu",
           "type": "string"
         },
@@ -436,7 +436,7 @@
       "type": "object"
     },
     "securityContext": {
-      "description": "Exporter container securityContext. Drops ALL capabilities, then adds only\nwhat GPU telemetry needs: PERFMON (Intel i915/xe engine utilization via the\nperf PMU) and SYS_RAWIO (Intel iGPU package temperature + the RAPL power\nfallback via /dev/cpu/*/msr, which needs the host msr kernel module). AMD and\nall sysfs-based stats need neither. Read-only root filesystem, no privilege\nescalation, not privileged.",
+      "description": "Exporter container securityContext. Drops ALL capabilities, then adds only\nwhat GPU telemetry needs: PERFMON (Intel i915/xe engine utilization via the\nperf PMU) and SYS_RAWIO (Intel iGPU package temperature + the RAPL power\nfallback via /dev/cpu/*/msr, which needs the host msr kernel module — absent on\nTalos, so drop SYS_RAWIO there). AMD and all sysfs-based stats need neither.\nRead-only root filesystem, no privilege escalation, not privileged.",
       "properties": {
         "allowPrivilegeEscalation": {
           "default": false,

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -67,14 +67,14 @@ serviceAccount:
 
 # Host access. Reading GPU stats requires the node's DRM device nodes and sysfs;
 # Intel iGPU package temperature (and the RAPL power fallback) additionally need
-# the per-CPU MSR device nodes, which require the host `msr` kernel module. Set a
-# path to "" to skip mounting it.
+# the per-CPU MSR device nodes, which require the host `msr` kernel module (not
+# shipped by Talos — see the devCpu note below). Set a path to "" to skip mounting it.
 hostAccess:
   # -- Host path for the DRM device nodes, mounted read-write; required to discover and read GPUs.
   devDri: /dev/dri
   # -- Host path for sysfs, mounted read-only; required for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats.
   sys: /sys
-  # -- Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module (Talos: load it via machine config). Harmless (unused) on AMD GPUs; set to "" to skip.
+  # -- Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module — autoloaded on most distros, but Talos does not ship it (siderolabs/extensions#620), so set this to "" on Talos (iGPU package temperature is then unavailable; engine/memory/frequency/power still work). Harmless (unused) on AMD GPUs; set to "" to skip.
   devCpu: /dev/cpu
   # -- Use host networking (scrape via the node IP:port instead of through the Service).
   hostNetwork: false
@@ -93,9 +93,9 @@ podSecurityContext:
 # -- Exporter container securityContext. Drops ALL capabilities, then adds only
 # what GPU telemetry needs: PERFMON (Intel i915/xe engine utilization via the
 # perf PMU) and SYS_RAWIO (Intel iGPU package temperature + the RAPL power
-# fallback via /dev/cpu/*/msr, which needs the host msr kernel module). AMD and
-# all sysfs-based stats need neither. Read-only root filesystem, no privilege
-# escalation, not privileged.
+# fallback via /dev/cpu/*/msr, which needs the host msr kernel module — absent on
+# Talos, so drop SYS_RAWIO there). AMD and all sysfs-based stats need neither.
+# Read-only root filesystem, no privilege escalation, not privileged.
 securityContext:
   privileged: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
## What

The chart `values.yaml` and the README told users to load the `msr` kernel
module on Talos via machine config. That's impossible: **Talos ships no `msr`
module and won't** — the maintainer treats userspace MSR access as a security
risk ([siderolabs/extensions#620](https://github.com/siderolabs/extensions/issues/620)).
With `machine.kernel.modules: [{name: msr}]` set, Talos's `KernelModuleSpecController`
just retry-fails every minute (`error loading module "msr": module not found`)
and `/dev/cpu/*/msr` never appears.

## Changes

Docs only — no behavior or default change:

- **README** privileges section and chart **`values.yaml`** comments now state
  that on Talos, Intel iGPU **package temperature** is unavailable, and the
  supported path is minimal-privilege: `hostAccess.devCpu: ""` and drop
  `SYS_RAWIO`. Engine utilization, memory, frequency, and **power** (the
  perf-PMU RAPL path, `CAP_PERFMON`) all still work.
- Regenerated `charts/drm-exporter/README.md` and `values.schema.json` from the
  updated `# --` comments.

Chart defaults are left as-is — they're correct for non-Talos hosts where the
`msr` module is available.
