### PR TITLE
feat(deps): update opentelemetry crates to 0.32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,9 +688,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -714,13 +714,14 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tonic",
+ "tonic-types",
 ]
 
 [[package]]
 name = "opentelemetry-prometheus"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14095eb06b569eb5d538fa4555969f7e8a410ed7910c903bfd295f9e1a50d7ea"
+checksum = "2c0359983e7f79cf33c9abd89e5d7ddf67c46c419d0148598022d70e70c01aba"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -731,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
@@ -744,15 +745,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand",
  "thiserror 2.0.18",
 ]
@@ -819,6 +821,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -872,6 +880,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -1235,6 +1252,17 @@ checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
+ "tonic",
+]
+
+[[package]]
+name = "tonic-types"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab1b02061f83d519bba3caa167f88f261ef05720ab8ebc954ade70de3348e8"
+dependencies = [
+ "prost",
+ "prost-types",
  "tonic",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,13 @@ clap = { version = "4.6.1", features = ["derive", "env", "wrap_help"] }
 ctrlc = { version = "3.5.2", features = ["termination"] }
 # Observability matches the org's other Rust project (kopiur): instrument on the
 # OpenTelemetry metrics API and expose a Prometheus pull endpoint via
-# opentelemetry-prometheus -> a prometheus Registry. Pinned to kopiur's versions.
+# opentelemetry-prometheus -> a prometheus Registry. Same stack as kopiur;
+# Renovate tracks these versions per-repo.
 # Pull-only (no OTLP push), so no async runtime is needed; tiny_http serves
 # /metrics + /health synchronously.
-opentelemetry = { version = "0.31", features = ["metrics"] }
-opentelemetry_sdk = { version = "0.31", features = ["metrics"] }
-opentelemetry-prometheus = "0.31"
+opentelemetry = { version = "0.32", features = ["metrics"] }
+opentelemetry_sdk = { version = "0.32", features = ["metrics"] }
+opentelemetry-prometheus = "0.32"
 prometheus = "0.14"
 tiny_http = "0.12"
 tracing = "0.1.44"
@@ -35,7 +36,7 @@ tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
 # by OTEL_EXPORTER_OTLP_ENDPOINT. The gRPC exporter's tonic channel needs a tokio
 # runtime, which Telemetry creates only when OTLP is configured — the default
 # Prometheus-pull path stays fully synchronous.
-opentelemetry-otlp = { version = "0.31", default-features = false, features = ["grpc-tonic", "metrics"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "metrics"] }
 tokio = { version = "1", default-features = false, features = ["rt-multi-thread", "net", "time"] }
 
 # qmlib (the qmassa GPU stats library) talks to DRM via udev/perf/sysfs and only


### PR DESCRIPTION
## What

Consolidates the four Renovate OpenTelemetry bumps into one PR. These crates are
released in lockstep and won't compile mixed across 0.31/0.32, so they belong in
a single change:

- `opentelemetry`            0.31.0 → 0.32.0
- `opentelemetry_sdk`        0.31.0 → 0.32.1
- `opentelemetry-otlp`       0.31.1 → 0.32.0
- `opentelemetry-prometheus` 0.31.0 → 0.32.0

Supersedes #5, #6, #7, #8 — they'll auto-close once this merges and the deps sit
at 0.32.

## Notes

- **No source changes** — the meter API, the `opentelemetry-prometheus` exporter,
  and the OTLP/gRPC builder this crate uses are unchanged across the bump; it
  compiles as-is.
- Verified: `cargo build` + `clippy -D warnings` + 18 tests (including the
  telemetry tests that construct both the Prometheus-only and OTLP provider
  paths), and `cargo deny` — advisories, bans, licenses, and sources all clean,
  including the new transitive deps `prost-types` 0.14.4 / `tonic-types` 0.14.6.
- Dropped the stale "pinned to kopiur's versions" comment: this moves
  drm-exporter to 0.32 ahead of kopiur (still on 0.31); Renovate tracks each repo
  independently.
