### PR TITLE
feat(chart)!: DRA ResourceClaimTemplate + require Kubernetes 1.34+

### DIFF
--- a/.lefthook.toml
+++ b/.lefthook.toml
@@ -28,6 +28,11 @@ exclude = [
 ]
 
 # Helm templates are Go-templated YAML (a `{{- if -}}` guard on line 1 is not
-# valid standalone YAML), so they can never be fed to a YAML formatter.
+# valid standalone YAML), so they can never be fed to a YAML formatter. The
+# `**/*.yaml` glob only matches nested files (e.g. templates/tests/), so list the
+# top-level templates separately too.
 [pre-commit.commands.format-yaml]
-exclude = ["charts/drm-exporter/templates/**/*.yaml"]
+exclude = [
+  "charts/drm-exporter/templates/*.yaml",
+  "charts/drm-exporter/templates/**/*.yaml",
+]

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ AMD GPUs and all sysfs-based stats need none of these. The Helm chart's default
 runs as root with just those two capabilities (not privileged, read-only root
 filesystem).
 
+On clusters with a Dynamic Resource Allocation (DRA) GPU driver, the chart can
+instead request GPUs through a `ResourceClaimTemplate` — by default an
+admin-access _monitor_ claim (read-only visibility of every GPU on the node,
+allocated as `All` and not counted as consumed). Enable it with
+`dra.enabled=true` (see the [chart README](charts/drm-exporter/README.md) for the
+`dra.*` values); it needs Kubernetes 1.34+ (`resource.k8s.io/v1`) and, for admin
+access, the namespace label `resource.kubernetes.io/admin-access: "true"`.
+
 ## Development
 
 The toolchain and tasks are managed by [mise](https://mise.jdx.dev):

--- a/charts/drm-exporter/Chart.yaml
+++ b/charts/drm-exporter/Chart.yaml
@@ -3,8 +3,9 @@ apiVersion: v2
 name: drm-exporter
 description: Prometheus exporter for Intel and AMD GPU metrics, deployed as a per-node DaemonSet
 type: application
-# DaemonSet (apps/v1) and the securityContext fields used here are stable from 1.25+.
-kubeVersion: ">=1.25.0-0"
+# Minimum supported Kubernetes is 1.36; this also covers the DRA
+# `resource.k8s.io/v1` API (GA since 1.34) used by the optional ResourceClaimTemplate.
+kubeVersion: ">=1.36.0-0"
 # version + appVersion are overridden at package time: version from the release
 # tag, appVersion from the same tag (the chart deploys the exporter's own image).
 version: 0.0.0

--- a/charts/drm-exporter/Chart.yaml
+++ b/charts/drm-exporter/Chart.yaml
@@ -3,9 +3,9 @@ apiVersion: v2
 name: drm-exporter
 description: Prometheus exporter for Intel and AMD GPU metrics, deployed as a per-node DaemonSet
 type: application
-# Minimum supported Kubernetes is 1.36; this also covers the DRA
-# `resource.k8s.io/v1` API (GA since 1.34) used by the optional ResourceClaimTemplate.
-kubeVersion: ">=1.36.0-0"
+# Minimum supported Kubernetes is 1.34, matching the DRA `resource.k8s.io/v1` API
+# (GA in 1.34) used by the optional ResourceClaimTemplate.
+kubeVersion: ">=1.34.0-0"
 # version + appVersion are overridden at package time: version from the release
 # tag, appVersion from the same tag (the chart deploys the exporter's own image).
 version: 0.0.0

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -91,7 +91,7 @@ them as the structured `config.*` values below, each mapping to a
 
 ## Requirements
 
-Kubernetes: `>=1.36.0-0`
+Kubernetes: `>=1.34.0-0`
 
 ## Values
 

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -110,7 +110,7 @@ Kubernetes: `>=1.36.0-0`
 | dra.count | int | `1` | Device count, used only when allocationMode is `ExactCount`. |
 | dra.deviceClassName | string | `""` | DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. Required when `dra.enabled`; no default. |
 | dra.enabled | bool | `false` | Create a ResourceClaimTemplate and have the DaemonSet pods consume it (DRA-based GPU access). |
-| dra.requestName | string | `"all-gpus"` | Name of the device request within the claim. |
+| dra.requestName | string | `""` | Name of the device request within the claim; empty derives it from the release name (the chart fullname). Claim-scoped, so it need not be unique across releases. |
 | dra.tolerations | list | `[{"effect":"NoExecute"},{"effect":"NoSchedule"}]` | Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern). |
 | env | object | `{}` | Extra environment variables for the container, as a map (templated). |
 | envFrom | list | `[]` | Sources of environment variables for the container (templated). |

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -108,7 +108,7 @@ Kubernetes: `>=1.25.0-0`
 | dra.annotations | object | `{}` | ResourceClaimTemplate annotations (templated). |
 | dra.apiVersion | string | `"resource.k8s.io/v1"` | ResourceClaimTemplate apiVersion; `resource.k8s.io/v1` is GA in Kubernetes 1.34. The rendered request uses the v1 `exactly` shape. |
 | dra.count | int | `1` | Device count, used only when allocationMode is `ExactCount`. |
-| dra.deviceClassName | string | `"gpu.intel.com"` | DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. |
+| dra.deviceClassName | string | `""` | DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. Required when `dra.enabled`; no default. |
 | dra.enabled | bool | `false` | Create a ResourceClaimTemplate and have the DaemonSet pods consume it (DRA-based GPU access). |
 | dra.requestName | string | `"all-gpus"` | Name of the device request within the claim. |
 | dra.tolerations | list | `[{"effect":"NoExecute"},{"effect":"NoSchedule"}]` | Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern). |
@@ -116,10 +116,10 @@ Kubernetes: `>=1.25.0-0`
 | envFrom | list | `[]` | Sources of environment variables for the container (templated). |
 | extraEnv | list | `[]` | Extra environment variables for the container, as a raw list (templated). |
 | fullnameOverride | string | `""` | Override the generated name used for every resource's `metadata.name` (the chart "fullname"). |
-| hostAccess.devCpu | string | `"/dev/cpu"` | Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module — autoloaded on most distros, but Talos does not ship it (siderolabs/extensions#620), so set this to "" on Talos (iGPU package temperature is then unavailable; engine/memory/frequency/power still work). Harmless (unused) on AMD GPUs; set to "" to skip. |
-| hostAccess.devDri | string | `"/dev/dri"` | Host path for the DRM device nodes, mounted read-write; required to discover and read GPUs. |
+| hostAccess.devCpu | string | `""` | Host path to the per-CPU MSR nodes, e.g. `/dev/cpu`, mounted read-only, for Intel iGPU package temperature (and the RAPL power fallback). Empty by default; set to `/dev/cpu` only on a non-Talos host with the `msr` kernel module loaded. Talos ships no `msr` (siderolabs/extensions#620); unused on AMD. |
+| hostAccess.devDri | string | `""` | Host path to the DRM device nodes, e.g. `/dev/dri`, mounted read-write to discover and read GPUs. Empty by default: set it for hostPath access, or leave empty and use DRA (`dra.enabled`), which injects the device instead. |
 | hostAccess.hostNetwork | bool | `false` | Use host networking (scrape via the node IP:port instead of through the Service). |
-| hostAccess.sys | string | `"/sys"` | Host path for sysfs, mounted read-only; required for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats. |
+| hostAccess.sys | string | `"/sys"` | Host path to sysfs, e.g. `/sys`, mounted read-only; required in both hostPath and DRA modes for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats. Set to "" to skip (rarely wanted). |
 | image.digest | string | `""` | Pin the image by digest (sha256:…); set by the release pipeline. When set, it overrides the tag. |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy. |
 | image.repository | string | `"ghcr.io/home-operations/drm-exporter"` | Image repository. |

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -111,7 +111,7 @@ Kubernetes: `>=1.36.0-0`
 | dra.deviceClassName | string | `""` | DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. Required when `dra.enabled`; no default. |
 | dra.enabled | bool | `false` | Create a ResourceClaimTemplate and have the DaemonSet pods consume it (DRA-based GPU access). |
 | dra.requestName | string | `""` | Name of the device request within the claim; empty derives it from the release name (the chart fullname). Claim-scoped, so it need not be unique across releases. |
-| dra.tolerations | list | `[{"effect":"NoExecute"},{"effect":"NoSchedule"}]` | Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern). |
+| dra.tolerations | list | `[]` | Device taint tolerations (DRA), letting the claim match tainted GPU devices. Empty by default; to monitor even tainted devices, add e.g. `- effect: NoSchedule` and `- effect: NoExecute`. |
 | env | object | `{}` | Extra environment variables for the container, as a map (templated). |
 | envFrom | list | `[]` | Sources of environment variables for the container (templated). |
 | extraEnv | list | `[]` | Extra environment variables for the container, as a raw list (templated). |

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -91,7 +91,7 @@ them as the structured `config.*` values below, each mapping to a
 
 ## Requirements
 
-Kubernetes: `>=1.25.0-0`
+Kubernetes: `>=1.36.0-0`
 
 ## Values
 

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -103,6 +103,15 @@ Kubernetes: `>=1.25.0-0`
 | config.logLevel | string | `"info"` | Log level (RUST_LOG): error, warn, info, debug, or trace. |
 | config.port | int | `9090` | Metrics HTTP listen port (DRM_EXPORTER_PORT); also the container and Service port. |
 | daemonsetAnnotations | object | `{}` | Annotations added to the DaemonSet (workload) metadata, e.g. `reloader.stakater.com/auto: "true"`. |
+| dra.adminAccess | bool | `true` | Request admin access: read-only visibility of devices, not counted as consumed. Requires the namespace label `resource.kubernetes.io/admin-access: "true"`. |
+| dra.allocationMode | string | `"All"` | Allocation mode: `All` (every matching device on the node) or `ExactCount`. |
+| dra.annotations | object | `{}` | ResourceClaimTemplate annotations (templated). |
+| dra.apiVersion | string | `"resource.k8s.io/v1"` | ResourceClaimTemplate apiVersion; `resource.k8s.io/v1` is GA in Kubernetes 1.34. The rendered request uses the v1 `exactly` shape. |
+| dra.count | int | `1` | Device count, used only when allocationMode is `ExactCount`. |
+| dra.deviceClassName | string | `"gpu.intel.com"` | DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. |
+| dra.enabled | bool | `false` | Create a ResourceClaimTemplate and have the DaemonSet pods consume it (DRA-based GPU access). |
+| dra.requestName | string | `"all-gpus"` | Name of the device request within the claim. |
+| dra.tolerations | list | `[{"effect":"NoExecute"},{"effect":"NoSchedule"}]` | Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern). |
 | env | object | `{}` | Extra environment variables for the container, as a map (templated). |
 | envFrom | list | `[]` | Sources of environment variables for the container (templated). |
 | extraEnv | list | `[]` | Extra environment variables for the container, as a raw list (templated). |

--- a/charts/drm-exporter/templates/_helpers.tpl
+++ b/charts/drm-exporter/templates/_helpers.tpl
@@ -81,3 +81,11 @@ Image for the `helm test` connection pod. tests.image.tag is pinned as
 {{- $img := .Values.tests.image -}}
 {{- printf "%s:%s" $img.repository $img.tag -}}
 {{- end }}
+
+{{/*
+Name of the GPU ResourceClaimTemplate (DRA). Shared by the template itself and
+the DaemonSet's resourceClaims reference.
+*/}}
+{{- define "drm-exporter.resourceClaimTemplateName" -}}
+{{- printf "%s-gpu" (include "drm-exporter.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end }}

--- a/charts/drm-exporter/templates/daemonset.yaml
+++ b/charts/drm-exporter/templates/daemonset.yaml
@@ -90,9 +90,15 @@ spec:
           readinessProbe:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- with .Values.resources }}
+          {{- if or .Values.resources .Values.dra.enabled }}
           resources:
+            {{- with .Values.resources }}
             {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- if .Values.dra.enabled }}
+            claims:
+              - name: gpu
+            {{- end }}
           {{- end }}
           volumeMounts:
             {{- if .Values.hostAccess.devDri }}
@@ -112,6 +118,11 @@ spec:
             {{- with .Values.volumeMounts }}
             {{- tpl (toYaml .) $ | nindent 12 }}
             {{- end }}
+      {{- if .Values.dra.enabled }}
+      resourceClaims:
+        - name: gpu
+          resourceClaimTemplateName: {{ include "drm-exporter.resourceClaimTemplateName" . }}
+      {{- end }}
       volumes:
         {{- if .Values.hostAccess.devDri }}
         - name: dev-dri

--- a/charts/drm-exporter/templates/resourceclaimtemplate.yaml
+++ b/charts/drm-exporter/templates/resourceclaimtemplate.yaml
@@ -19,7 +19,7 @@ spec:
       requests:
         - name: {{ .Values.dra.requestName }}
           exactly:
-            deviceClassName: {{ .Values.dra.deviceClassName }}
+            deviceClassName: {{ required "dra.deviceClassName is required when dra.enabled (e.g. gpu.intel.com or gpu.nvidia.com)" .Values.dra.deviceClassName }}
             {{- if .Values.dra.adminAccess }}
             adminAccess: true
             {{- end }}

--- a/charts/drm-exporter/templates/resourceclaimtemplate.yaml
+++ b/charts/drm-exporter/templates/resourceclaimtemplate.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.dra.enabled }}
+apiVersion: {{ .Values.dra.apiVersion }}
+kind: ResourceClaimTemplate
+metadata:
+  name: {{ include "drm-exporter.resourceClaimTemplateName" . }}
+  labels:
+    {{- include "drm-exporter.labels" . | nindent 4 }}
+  {{- with .Values.dra.annotations }}
+  annotations:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+spec:
+  # ResourceClaimTemplate.spec.spec is the ResourceClaimSpec stamped into every
+  # generated claim. The default is an admin-access monitor request: read-only
+  # visibility of all GPUs on the node, allocated as `All` and not counted as
+  # consumed (so it never steals a VF from a workload).
+  spec:
+    devices:
+      requests:
+        - name: {{ .Values.dra.requestName }}
+          exactly:
+            deviceClassName: {{ .Values.dra.deviceClassName }}
+            {{- if .Values.dra.adminAccess }}
+            adminAccess: true
+            {{- end }}
+            allocationMode: {{ .Values.dra.allocationMode }}
+            {{- if eq .Values.dra.allocationMode "ExactCount" }}
+            count: {{ .Values.dra.count }}
+            {{- end }}
+            {{- with .Values.dra.tolerations }}
+            tolerations:
+              {{- toYaml . | nindent 14 }}
+            {{- end }}
+{{- end }}

--- a/charts/drm-exporter/templates/resourceclaimtemplate.yaml
+++ b/charts/drm-exporter/templates/resourceclaimtemplate.yaml
@@ -17,7 +17,7 @@ spec:
   spec:
     devices:
       requests:
-        - name: {{ .Values.dra.requestName }}
+        - name: {{ .Values.dra.requestName | default (include "drm-exporter.fullname" .) }}
           exactly:
             deviceClassName: {{ required "dra.deviceClassName is required when dra.enabled (e.g. gpu.intel.com or gpu.nvidia.com)" .Values.dra.deviceClassName }}
             {{- if .Values.dra.adminAccess }}

--- a/charts/drm-exporter/tests/daemonset_test.yaml
+++ b/charts/drm-exporter/tests/daemonset_test.yaml
@@ -115,8 +115,34 @@ tests:
           path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
           value: true
 
-  - it: mounts the host DRM, sysfs, and MSR paths by default
+  - it: mounts only sysfs by default; the device nodes are opt-in
     template: daemonset.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: sys
+            hostPath:
+              path: /sys
+              type: Directory
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: dev-dri
+            hostPath:
+              path: /dev/dri
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: dev-cpu
+            mountPath: /dev/cpu
+            readOnly: true
+
+  - it: mounts the DRM and MSR host paths when configured
+    template: daemonset.yaml
+    set:
+      hostAccess.devDri: /dev/dri
+      hostAccess.devCpu: /dev/cpu
     asserts:
       - contains:
           path: spec.template.spec.volumes
@@ -125,36 +151,11 @@ tests:
             hostPath:
               path: /dev/dri
       - contains:
-          path: spec.template.spec.volumes
-          content:
-            name: sys
-            hostPath:
-              path: /sys
-              type: Directory
-      - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             name: dev-cpu
             mountPath: /dev/cpu
             readOnly: true
-
-  - it: drops the MSR mount when hostAccess.devCpu is empty
-    template: daemonset.yaml
-    set:
-      hostAccess.devCpu: ""
-    asserts:
-      - notContains:
-          path: spec.template.spec.containers[0].volumeMounts
-          content:
-            name: dev-cpu
-            mountPath: /dev/cpu
-            readOnly: true
-      - notContains:
-          path: spec.template.spec.volumes
-          content:
-            name: dev-cpu
-            hostPath:
-              path: /dev/cpu
 
   - it: enables host networking with the matching DNS policy
     template: daemonset.yaml

--- a/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
+++ b/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
@@ -45,9 +45,8 @@ tests:
       - equal:
           path: spec.spec.devices.requests[0].exactly.allocationMode
           value: All
-      - equal:
-          path: spec.spec.devices.requests[0].exactly.tolerations[0].effect
-          value: NoExecute
+      - notExists:
+          path: spec.spec.devices.requests[0].exactly.tolerations
       - notExists:
           path: spec.spec.devices.requests[0].exactly.count
 
@@ -102,6 +101,22 @@ tests:
       - equal:
           path: spec.spec.devices.requests[0].name
           value: my-gpus
+
+  - it: renders device tolerations when set
+    template: resourceclaimtemplate.yaml
+    set:
+      dra.enabled: true
+      dra.deviceClassName: gpu.intel.com
+      dra.tolerations:
+        - effect: NoExecute
+        - effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.tolerations[0].effect
+          value: NoExecute
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.tolerations[1].effect
+          value: NoSchedule
 
   - it: requires a deviceClassName when enabled
     template: resourceclaimtemplate.yaml

--- a/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
+++ b/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
@@ -35,7 +35,7 @@ tests:
           value: RELEASE-NAME-drm-exporter-gpu
       - equal:
           path: spec.spec.devices.requests[0].name
-          value: all-gpus
+          value: RELEASE-NAME-drm-exporter
       - equal:
           path: spec.spec.devices.requests[0].exactly.deviceClassName
           value: gpu.intel.com
@@ -91,6 +91,17 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.claims[0].name
           value: gpu
+
+  - it: honors an explicit requestName
+    template: resourceclaimtemplate.yaml
+    set:
+      dra.enabled: true
+      dra.deviceClassName: gpu.intel.com
+      dra.requestName: my-gpus
+    asserts:
+      - equal:
+          path: spec.spec.devices.requests[0].name
+          value: my-gpus
 
   - it: requires a deviceClassName when enabled
     template: resourceclaimtemplate.yaml

--- a/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
+++ b/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
@@ -22,6 +22,7 @@ tests:
     template: resourceclaimtemplate.yaml
     set:
       dra.enabled: true
+      dra.deviceClassName: gpu.intel.com
     asserts:
       - hasDocuments:
           count: 1
@@ -54,6 +55,7 @@ tests:
     template: resourceclaimtemplate.yaml
     set:
       dra.enabled: true
+      dra.deviceClassName: gpu.intel.com
       dra.allocationMode: ExactCount
       dra.count: 2
     asserts:
@@ -68,6 +70,7 @@ tests:
     template: resourceclaimtemplate.yaml
     set:
       dra.enabled: true
+      dra.deviceClassName: gpu.intel.com
       dra.adminAccess: false
     asserts:
       - notExists:
@@ -77,6 +80,7 @@ tests:
     template: daemonset.yaml
     set:
       dra.enabled: true
+      dra.deviceClassName: gpu.intel.com
     asserts:
       - equal:
           path: spec.template.spec.resourceClaims[0].name
@@ -87,3 +91,11 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].resources.claims[0].name
           value: gpu
+
+  - it: requires a deviceClassName when enabled
+    template: resourceclaimtemplate.yaml
+    set:
+      dra.enabled: true
+    asserts:
+      - failedTemplate:
+          errorPattern: deviceClassName is required when dra\.enabled

--- a/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
+++ b/charts/drm-exporter/tests/resourceclaimtemplate_test.yaml
@@ -1,0 +1,89 @@
+suite: resourceclaimtemplate
+templates:
+  - resourceclaimtemplate.yaml
+  - daemonset.yaml
+  - _helpers.tpl
+tests:
+  - it: is not created by default
+    template: resourceclaimtemplate.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: the daemonset declares no resource claims by default
+    template: daemonset.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.resourceClaims
+      - notExists:
+          path: spec.template.spec.containers[0].resources.claims
+
+  - it: renders an admin-access monitor claim when enabled
+    template: resourceclaimtemplate.yaml
+    set:
+      dra.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ResourceClaimTemplate
+      - isAPIVersion:
+          of: resource.k8s.io/v1
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-drm-exporter-gpu
+      - equal:
+          path: spec.spec.devices.requests[0].name
+          value: all-gpus
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.deviceClassName
+          value: gpu.intel.com
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.adminAccess
+          value: true
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.allocationMode
+          value: All
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.tolerations[0].effect
+          value: NoExecute
+      - notExists:
+          path: spec.spec.devices.requests[0].exactly.count
+
+  - it: uses count only in ExactCount mode
+    template: resourceclaimtemplate.yaml
+    set:
+      dra.enabled: true
+      dra.allocationMode: ExactCount
+      dra.count: 2
+    asserts:
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.allocationMode
+          value: ExactCount
+      - equal:
+          path: spec.spec.devices.requests[0].exactly.count
+          value: 2
+
+  - it: omits adminAccess when disabled
+    template: resourceclaimtemplate.yaml
+    set:
+      dra.enabled: true
+      dra.adminAccess: false
+    asserts:
+      - notExists:
+          path: spec.spec.devices.requests[0].exactly.adminAccess
+
+  - it: the daemonset consumes the claim when enabled
+    template: daemonset.yaml
+    set:
+      dra.enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.resourceClaims[0].name
+          value: gpu
+      - equal:
+          path: spec.template.spec.resourceClaims[0].resourceClaimTemplateName
+          value: RELEASE-NAME-drm-exporter-gpu
+      - equal:
+          path: spec.template.spec.containers[0].resources.claims[0].name
+          value: gpu

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -93,8 +93,8 @@
           "type": "boolean"
         },
         "requestName": {
-          "default": "all-gpus",
-          "description": "Name of the device request within the claim.",
+          "default": "",
+          "description": "Name of the device request within the claim; empty derives it from the release name (the chart fullname). Claim-scoped, so it need not be unique across releases.",
           "title": "requestName",
           "type": "string"
         },

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -47,6 +47,94 @@
       "title": "daemonsetAnnotations",
       "type": "object"
     },
+    "dra": {
+      "description": "Dynamic Resource Allocation (DRA). On a cluster with a DRA GPU driver (e.g. the\nIntel GPU resource driver, device class `gpu.intel.com`), the exporter can claim\nGPU devices through a ResourceClaimTemplate instead of, or alongside, the\nhostAccess mounts. The default is an admin-access *monitor* claim: read-only\nvisibility of every GPU on the node, allocated as `All` and not counted as\nconsumed (so it never steals a VF from a workload). Admin access requires the\nrelease namespace to carry the label `resource.kubernetes.io/admin-access: \"true\"`.\nOff by default; `resource.k8s.io/v1` is GA in Kubernetes 1.34.",
+      "properties": {
+        "adminAccess": {
+          "default": true,
+          "description": "Request admin access: read-only visibility of devices, not counted as consumed. Requires the namespace label `resource.kubernetes.io/admin-access: \"true\"`.",
+          "title": "adminAccess",
+          "type": "boolean"
+        },
+        "allocationMode": {
+          "default": "All",
+          "description": "Allocation mode: `All` (every matching device on the node) or `ExactCount`.",
+          "title": "allocationMode",
+          "type": "string"
+        },
+        "annotations": {
+          "description": "ResourceClaimTemplate annotations (templated).",
+          "required": [],
+          "title": "annotations",
+          "type": "object"
+        },
+        "apiVersion": {
+          "default": "resource.k8s.io/v1",
+          "description": "ResourceClaimTemplate apiVersion; `resource.k8s.io/v1` is GA in Kubernetes 1.34. The rendered request uses the v1 `exactly` shape.",
+          "title": "apiVersion",
+          "type": "string"
+        },
+        "count": {
+          "default": 1,
+          "description": "Device count, used only when allocationMode is `ExactCount`.",
+          "title": "count",
+          "type": "integer"
+        },
+        "deviceClassName": {
+          "default": "gpu.intel.com",
+          "description": "DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`.",
+          "title": "deviceClassName",
+          "type": "string"
+        },
+        "enabled": {
+          "default": false,
+          "description": "Create a ResourceClaimTemplate and have the DaemonSet pods consume it (DRA-based GPU access).",
+          "title": "enabled",
+          "type": "boolean"
+        },
+        "requestName": {
+          "default": "all-gpus",
+          "description": "Name of the device request within the claim.",
+          "title": "requestName",
+          "type": "string"
+        },
+        "tolerations": {
+          "description": "Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern).",
+          "items": {
+            "anyOf": [
+              {
+                "properties": {
+                  "effect": {
+                    "default": "NoExecute",
+                    "title": "effect",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              },
+              {
+                "properties": {
+                  "effect": {
+                    "default": "NoSchedule",
+                    "title": "effect",
+                    "type": "string"
+                  }
+                },
+                "required": [],
+                "type": "object"
+              }
+            ],
+            "required": []
+          },
+          "title": "tolerations",
+          "type": "array"
+        }
+      },
+      "required": [],
+      "title": "dra",
+      "type": "object"
+    },
     "env": {
       "description": "Extra environment variables for the container, as a map (templated).",
       "required": [],

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -99,32 +99,8 @@
           "type": "string"
         },
         "tolerations": {
-          "description": "Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern).",
+          "description": "Device taint tolerations (DRA), letting the claim match tainted GPU devices. Empty by default; to monitor even tainted devices, add e.g. `- effect: NoSchedule` and `- effect: NoExecute`.",
           "items": {
-            "anyOf": [
-              {
-                "properties": {
-                  "effect": {
-                    "default": "NoExecute",
-                    "title": "effect",
-                    "type": "string"
-                  }
-                },
-                "required": [],
-                "type": "object"
-              },
-              {
-                "properties": {
-                  "effect": {
-                    "default": "NoSchedule",
-                    "title": "effect",
-                    "type": "string"
-                  }
-                },
-                "required": [],
-                "type": "object"
-              }
-            ],
             "required": []
           },
           "title": "tolerations",

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -81,8 +81,8 @@
           "type": "integer"
         },
         "deviceClassName": {
-          "default": "gpu.intel.com",
-          "description": "DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`.",
+          "default": "",
+          "description": "DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. Required when `dra.enabled`; no default.",
           "title": "deviceClassName",
           "type": "string"
         },
@@ -170,17 +170,17 @@
       "type": "object"
     },
     "hostAccess": {
-      "description": "Host access. Reading GPU stats requires the node's DRM device nodes and sysfs;\nIntel iGPU package temperature (and the RAPL power fallback) additionally need\nthe per-CPU MSR device nodes, which require the host `msr` kernel module (not\nshipped by Talos — see the devCpu note below). Set a path to \"\" to skip mounting it.",
+      "description": "Host access for reading GPU stats. `sys` (host /sys) is always needed — that is\nwhere frequency, memory, AMD engine, and hwmon stats are read, in both hostPath\nand DRA modes. The two device-node paths default to empty (nothing mounted); set\nthe one that matches how you grant device access:\n  - devDri: set to \"/dev/dri\" for plain hostPath access. Leave empty when using\n    DRA (dra.enabled) — the GPU driver injects the device via CDI, and a hostPath\n    /dev/dri is cgroup-blocked for a non-privileged container anyway.\n  - devCpu: set to \"/dev/cpu\" only to read Intel iGPU package temperature via MSR,\n    on a non-Talos host with the `msr` kernel module loaded. Talos ships no `msr`\n    (see the README) and it is unused on AMD.\nGrant access via devDri OR dra.enabled; with neither, the exporter starts but\nfinds no GPUs.",
       "properties": {
         "devCpu": {
-          "default": "/dev/cpu",
-          "description": "Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module — autoloaded on most distros, but Talos does not ship it (siderolabs/extensions#620), so set this to \"\" on Talos (iGPU package temperature is then unavailable; engine/memory/frequency/power still work). Harmless (unused) on AMD GPUs; set to \"\" to skip.",
+          "default": "",
+          "description": "Host path to the per-CPU MSR nodes, e.g. `/dev/cpu`, mounted read-only, for Intel iGPU package temperature (and the RAPL power fallback). Empty by default; set to `/dev/cpu` only on a non-Talos host with the `msr` kernel module loaded. Talos ships no `msr` (siderolabs/extensions#620); unused on AMD.",
           "title": "devCpu",
           "type": "string"
         },
         "devDri": {
-          "default": "/dev/dri",
-          "description": "Host path for the DRM device nodes, mounted read-write; required to discover and read GPUs.",
+          "default": "",
+          "description": "Host path to the DRM device nodes, e.g. `/dev/dri`, mounted read-write to discover and read GPUs. Empty by default: set it for hostPath access, or leave empty and use DRA (`dra.enabled`), which injects the device instead.",
           "title": "devDri",
           "type": "string"
         },
@@ -192,7 +192,7 @@
         },
         "sys": {
           "default": "/sys",
-          "description": "Host path for sysfs, mounted read-only; required for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats.",
+          "description": "Host path to sysfs, e.g. `/sys`, mounted read-only; required in both hostPath and DRA modes for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats. Set to \"\" to skip (rarely wanted).",
           "title": "sys",
           "type": "string"
         }

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -79,6 +79,36 @@ hostAccess:
   # -- Use host networking (scrape via the node IP:port instead of through the Service).
   hostNetwork: false
 
+# Dynamic Resource Allocation (DRA). On a cluster with a DRA GPU driver (e.g. the
+# Intel GPU resource driver, device class `gpu.intel.com`), the exporter can claim
+# GPU devices through a ResourceClaimTemplate instead of, or alongside, the
+# hostAccess mounts. The default is an admin-access *monitor* claim: read-only
+# visibility of every GPU on the node, allocated as `All` and not counted as
+# consumed (so it never steals a VF from a workload). Admin access requires the
+# release namespace to carry the label `resource.kubernetes.io/admin-access: "true"`.
+# Off by default; `resource.k8s.io/v1` is GA in Kubernetes 1.34.
+dra:
+  # -- Create a ResourceClaimTemplate and have the DaemonSet pods consume it (DRA-based GPU access).
+  enabled: false
+  # -- ResourceClaimTemplate apiVersion; `resource.k8s.io/v1` is GA in Kubernetes 1.34. The rendered request uses the v1 `exactly` shape.
+  apiVersion: resource.k8s.io/v1
+  # -- ResourceClaimTemplate annotations (templated).
+  annotations: {}
+  # -- Name of the device request within the claim.
+  requestName: all-gpus
+  # -- DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`.
+  deviceClassName: gpu.intel.com
+  # -- Request admin access: read-only visibility of devices, not counted as consumed. Requires the namespace label `resource.kubernetes.io/admin-access: "true"`.
+  adminAccess: true
+  # -- Allocation mode: `All` (every matching device on the node) or `ExactCount`.
+  allocationMode: All
+  # -- Device count, used only when allocationMode is `ExactCount`.
+  count: 1
+  # -- Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern).
+  tolerations:
+    - effect: NoExecute
+    - effect: NoSchedule
+
 # -- Pod-level securityContext. The exporter runs as root by default because GPU
 # telemetry needs MSR access (Intel package power) and the perf PMU on
 # locked-down kernels; see `securityContext` for the (narrow) capability set.

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -65,17 +65,25 @@ serviceAccount:
   # -- ServiceAccount annotations.
   annotations: {}
 
-# Host access. Reading GPU stats requires the node's DRM device nodes and sysfs;
-# Intel iGPU package temperature (and the RAPL power fallback) additionally need
-# the per-CPU MSR device nodes, which require the host `msr` kernel module (not
-# shipped by Talos — see the devCpu note below). Set a path to "" to skip mounting it.
+# Host access for reading GPU stats. `sys` (host /sys) is always needed — that is
+# where frequency, memory, AMD engine, and hwmon stats are read, in both hostPath
+# and DRA modes. The two device-node paths default to empty (nothing mounted); set
+# the one that matches how you grant device access:
+#   - devDri: set to "/dev/dri" for plain hostPath access. Leave empty when using
+#     DRA (dra.enabled) — the GPU driver injects the device via CDI, and a hostPath
+#     /dev/dri is cgroup-blocked for a non-privileged container anyway.
+#   - devCpu: set to "/dev/cpu" only to read Intel iGPU package temperature via MSR,
+#     on a non-Talos host with the `msr` kernel module loaded. Talos ships no `msr`
+#     (see the README) and it is unused on AMD.
+# Grant access via devDri OR dra.enabled; with neither, the exporter starts but
+# finds no GPUs.
 hostAccess:
-  # -- Host path for the DRM device nodes, mounted read-write; required to discover and read GPUs.
-  devDri: /dev/dri
-  # -- Host path for sysfs, mounted read-only; required for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats.
+  # -- Host path to the DRM device nodes, e.g. `/dev/dri`, mounted read-write to discover and read GPUs. Empty by default: set it for hostPath access, or leave empty and use DRA (`dra.enabled`), which injects the device instead.
+  devDri: ""
+  # -- Host path to sysfs, e.g. `/sys`, mounted read-only; required in both hostPath and DRA modes for frequency, memory, AMD engine, and hwmon (temp/fan/power) stats. Set to "" to skip (rarely wanted).
   sys: /sys
-  # -- Host path for the per-CPU MSR nodes, mounted read-only, for Intel iGPU package temperature and the RAPL power fallback. Needs the host `msr` kernel module — autoloaded on most distros, but Talos does not ship it (siderolabs/extensions#620), so set this to "" on Talos (iGPU package temperature is then unavailable; engine/memory/frequency/power still work). Harmless (unused) on AMD GPUs; set to "" to skip.
-  devCpu: /dev/cpu
+  # -- Host path to the per-CPU MSR nodes, e.g. `/dev/cpu`, mounted read-only, for Intel iGPU package temperature (and the RAPL power fallback). Empty by default; set to `/dev/cpu` only on a non-Talos host with the `msr` kernel module loaded. Talos ships no `msr` (siderolabs/extensions#620); unused on AMD.
+  devCpu: ""
   # -- Use host networking (scrape via the node IP:port instead of through the Service).
   hostNetwork: false
 
@@ -96,8 +104,8 @@ dra:
   annotations: {}
   # -- Name of the device request within the claim.
   requestName: all-gpus
-  # -- DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`.
-  deviceClassName: gpu.intel.com
+  # -- DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. Required when `dra.enabled`; no default.
+  deviceClassName: ""
   # -- Request admin access: read-only visibility of devices, not counted as consumed. Requires the namespace label `resource.kubernetes.io/admin-access: "true"`.
   adminAccess: true
   # -- Allocation mode: `All` (every matching device on the node) or `ExactCount`.

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -112,10 +112,8 @@ dra:
   allocationMode: All
   # -- Device count, used only when allocationMode is `ExactCount`.
   count: 1
-  # -- Device tolerations, letting the claim match tainted devices; the default tolerates the NoSchedule and NoExecute device taints (the monitor-claim pattern).
-  tolerations:
-    - effect: NoExecute
-    - effect: NoSchedule
+  # -- Device taint tolerations (DRA), letting the claim match tainted GPU devices. Empty by default; to monitor even tainted devices, add e.g. `- effect: NoSchedule` and `- effect: NoExecute`.
+  tolerations: []
 
 # -- Pod-level securityContext. The exporter runs as root by default because GPU
 # telemetry needs MSR access (Intel package power) and the perf PMU on

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -102,8 +102,8 @@ dra:
   apiVersion: resource.k8s.io/v1
   # -- ResourceClaimTemplate annotations (templated).
   annotations: {}
-  # -- Name of the device request within the claim.
-  requestName: all-gpus
+  # -- Name of the device request within the claim; empty derives it from the release name (the chart fullname). Claim-scoped, so it need not be unique across releases.
+  requestName: ""
   # -- DRA device class to request (the GPU driver's class), e.g. `gpu.intel.com` or `gpu.nvidia.com`. Required when `dra.enabled`; no default.
   deviceClassName: ""
   # -- Request admin access: read-only visibility of devices, not counted as consumed. Requires the namespace label `resource.kubernetes.io/admin-access: "true"`.


### PR DESCRIPTION
## What

Adds optional Dynamic Resource Allocation (DRA) support to the chart: a
`ResourceClaimTemplate` the DaemonSet pods consume, so on clusters with a DRA GPU
driver the exporter can claim GPUs that way instead of (or alongside) the
`hostAccess` device mounts.

Enabling it minimally (`dra.enabled=true`, `dra.deviceClassName=gpu.intel.com` —
`deviceClassName` is required, no default) renders an admin-access **monitor**
claim: read-only visibility of every GPU on the node, allocated as `All`, not
counted as consumed:

```yaml
apiVersion: resource.k8s.io/v1
kind: ResourceClaimTemplate
metadata:
  name: <release>-drm-exporter-gpu
spec:
  spec:
    devices:
      requests:
        - name: <release>-drm-exporter # requestName default: release-derived
          exactly:
            deviceClassName: gpu.intel.com
            adminAccess: true
            allocationMode: All
            # tolerations: [] by default — add device taint tolerations here
            # (e.g. - effect: NoSchedule) only if your GPUs are tainted.
```

## Chart values (all DRA values off/empty by default)

- `dra.enabled` (false), `dra.apiVersion` (`resource.k8s.io/v1`), `dra.annotations`.
- `dra.deviceClassName` — **required** when enabled (`""` default; the template
  `required`s it with a clear message).
- `dra.requestName` — `""` default, derived from the release name (chart
  fullname); claim-scoped, overridable.
- `dra.adminAccess` (true), `dra.allocationMode` (`All`) / `dra.count`.
- `dra.tolerations` — `[]` default (device taints opt-in), matching the pod
  `tolerations` default.

## Also in this PR

- DaemonSet consumes the claim (pod `resourceClaims` + container `resources.claims`)
  when enabled; unchanged when disabled.
- `hostAccess.devDri` and `devCpu` now default to `""` (opt-in); `sys` stays `/sys`
  (needed in both modes). Grant device access via `devDri` **or** `dra.enabled`.
- Raises the chart `kubeVersion` floor to `>=1.34.0-0` (was `>=1.25`), matching the
  DRA `resource.k8s.io/v1` GA — a breaking change to the support matrix, hence
  `feat(chart)!` (release-please cuts 0.2.0).
- Fixes the `format-yaml` lefthook exclude, which only matched template files in
  subdirectories (top-level Helm templates were not excluded).
- helm-unittest suite (32 tests total) + regenerated chart README/schema + a
  README note.

## Requirements

DRA `resource.k8s.io/v1` is GA in Kubernetes 1.34 (matching the chart floor);
admin access needs the namespace label `resource.kubernetes.io/admin-access: "true"`.
