### PR TITLE
feat: change the default metrics port to 8081

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,5 @@ COPY --from=builder /usr/local/bin/drm-exporter /usr/local/bin/drm-exporter
 # libcap.so.2 (glibc/libgcc come from the cc base).
 COPY --from=builder /usr/lib/*/libudev.so.1* /usr/lib/
 COPY --from=builder /usr/lib/*/libcap.so.2* /usr/lib/
-EXPOSE 9090
+EXPOSE 8081
 ENTRYPOINT ["/usr/local/bin/drm-exporter"]

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Every flag has a `DRM_EXPORTER_*` environment variable equivalent:
 | Flag                       | Env                             | Default             | Description                                            |
 | -------------------------- | ------------------------------- | ------------------- | ------------------------------------------------------ |
 | `-a`, `--address`          | `DRM_EXPORTER_ADDRESS`          | `0.0.0.0`           | Metrics HTTP bind address                              |
-| `-p`, `--port`             | `DRM_EXPORTER_PORT`             | `9090`              | Metrics HTTP port                                      |
+| `-p`, `--port`             | `DRM_EXPORTER_PORT`             | `8081`              | Metrics HTTP port                                      |
 | `-i`, `--interval-seconds` | `DRM_EXPORTER_INTERVAL_SECONDS` | `5`                 | Seconds between GPU stat refreshes                     |
 | `-d`, `--devices`          | `DRM_EXPORTER_DEVICES`          | _(all)_             | Comma-separated PCI slots to export                    |
 | `--driver-option`          | —                               | _(driver defaults)_ | Advanced qmlib `driver=key=value` options (repeatable) |
@@ -77,7 +77,7 @@ docker run --rm \
   --device /dev/dri \
   -v /sys:/sys:ro \
   --cap-add PERFMON --cap-add SYS_RAWIO \
-  -p 9090:9090 \
+  -p 8081:8081 \
   ghcr.io/home-operations/drm-exporter:latest
 ```
 

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -101,7 +101,7 @@ Kubernetes: `>=1.34.0-0`
 | config.devices | list | `[]` | Restrict export to specific PCI slots, e.g. `["0000:03:00.0"]` (DRM_EXPORTER_DEVICES); empty exports every GPU discovered. |
 | config.intervalSeconds | int | `5` | Seconds between GPU stat refreshes (DRM_EXPORTER_INTERVAL_SECONDS). Intel engine utilization is sampled across this window, so keep it at or below the Prometheus scrape interval. |
 | config.logLevel | string | `"info"` | Log level (RUST_LOG): error, warn, info, debug, or trace. |
-| config.port | int | `9090` | Metrics HTTP listen port (DRM_EXPORTER_PORT); also the container and Service port. |
+| config.port | int | `8081` | Metrics HTTP listen port (DRM_EXPORTER_PORT); also the container and Service port. |
 | daemonsetAnnotations | object | `{}` | Annotations added to the DaemonSet (workload) metadata, e.g. `reloader.stakater.com/auto: "true"`. |
 | dra.adminAccess | bool | `true` | Request admin access: read-only visibility of devices, not counted as consumed. Requires the namespace label `resource.kubernetes.io/admin-access: "true"`. |
 | dra.allocationMode | string | `"All"` | Allocation mode: `All` (every matching device on the node) or `ExactCount`. |

--- a/charts/drm-exporter/tests/daemonset_test.yaml
+++ b/charts/drm-exporter/tests/daemonset_test.yaml
@@ -43,7 +43,7 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: DRM_EXPORTER_PORT
-            value: "9090"
+            value: "8081"
       - contains:
           path: spec.template.spec.containers[0].env
           content:
@@ -90,7 +90,7 @@ tests:
           path: spec.template.spec.containers[0].ports
           content:
             name: metrics
-            containerPort: 9090
+            containerPort: 8081
             protocol: TCP
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path

--- a/charts/drm-exporter/tests/service_test.yaml
+++ b/charts/drm-exporter/tests/service_test.yaml
@@ -15,7 +15,7 @@ tests:
           path: spec.ports
           content:
             name: metrics
-            port: 9090
+            port: 8081
             targetPort: metrics
             protocol: TCP
 

--- a/charts/drm-exporter/tests/test-connection_test.yaml
+++ b/charts/drm-exporter/tests/test-connection_test.yaml
@@ -19,4 +19,4 @@ tests:
           pattern: '^mirror\.gcr\.io/curlimages/curl:'
       - contains:
           path: spec.containers[0].args
-          content: http://RELEASE-NAME-drm-exporter:9090/health
+          content: http://RELEASE-NAME-drm-exporter:8081/health

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -31,7 +31,7 @@
           "type": "string"
         },
         "port": {
-          "default": 9090,
+          "default": 8081,
           "description": "Metrics HTTP listen port (DRM_EXPORTER_PORT); also the container and Service port.",
           "title": "port",
           "type": "integer"

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -31,7 +31,7 @@ fullnameOverride: ""
 # RUST_LOG) environment variable the binary reads; see the README for details.
 config:
   # -- Metrics HTTP listen port (DRM_EXPORTER_PORT); also the container and Service port.
-  port: 9090
+  port: 8081
   # -- Seconds between GPU stat refreshes (DRM_EXPORTER_INTERVAL_SECONDS). Intel engine utilization is sampled across this window, so keep it at or below the Prometheus scrape interval.
   intervalSeconds: 5
   # -- Restrict export to specific PCI slots, e.g. `["0000:03:00.0"]` (DRM_EXPORTER_DEVICES); empty exports every GPU discovered.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Args {
     pub address: IpAddr,
 
     /// Port the metrics HTTP server listens on.
-    #[arg(short, long, default_value_t = 9090, env = "DRM_EXPORTER_PORT")]
+    #[arg(short, long, default_value_t = 8081, env = "DRM_EXPORTER_PORT")]
     pub port: u16,
 
     /// Seconds between GPU stat refreshes. Intel engine utilization is sampled
@@ -71,7 +71,7 @@ mod tests {
     fn defaults_match_the_documented_values() {
         let args = Args::parse_from(["drm-exporter"]);
         assert_eq!(args.address.to_string(), "0.0.0.0");
-        assert_eq!(args.port, 9090);
+        assert_eq!(args.port, 8081);
         assert_eq!(args.interval_seconds, 5);
         assert!(args.devices.is_empty());
         assert!(args.driver_options.is_empty());


### PR DESCRIPTION
## What

Changes the default metrics port from **9090 → 8081** — the `DRM_EXPORTER_PORT`
default and the chart's container/Service port (and the docker `EXPOSE`).

## Why

9090 is conventionally the Prometheus **server's** own port, so the exporter's
default collided with it on shared host networking. 8081 sidesteps that. Still
overridable via `--port` / `DRM_EXPORTER_PORT` / `config.port`.

## Notes

- The chart's ServiceMonitor scrapes by port **name** (`metrics`), so in-chart
  monitoring is unaffected by the number change.
- Classified `feat` (pre-1.0 patch). It does change the released default, so
  anything *external* pinned to `:9090` (scrape configs, NetworkPolicy, firewall)
  must update — shout if you'd prefer it marked `feat!` for a minor signal.
- Verified: `mise run ci` (fmt + clippy + 18 tests incl. the `8081` default
  assertion), `helm lint`, 32/32 helm-unittests; chart README/schema regenerated.
