### PR TITLE
feat(chart): distinguish nodes in the Grafana dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,9 @@ A Grafana dashboard ships with the chart. Enable it with
 `grafana_dashboard: "1"` for the kube-prometheus-stack sidecar), or set
 `monitoring.dashboards.grafanaOperator.enabled=true` for a grafana-operator
 `GrafanaDashboard`. It charts engine utilization, memory, frequency, power, and
-temperature per GPU, with a `device` selector.
+temperature per GPU, with `node` and `device` selectors (the chart's
+ServiceMonitor adds the `node` label so a DaemonSet across many nodes stays
+distinguishable).
 
 ## Privileges
 

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -142,7 +142,7 @@ Kubernetes: `>=1.34.0-0`
 | monitoring.serviceMonitor.labels | object | `{}` | ServiceMonitor labels. |
 | monitoring.serviceMonitor.metricRelabelings | list | `[]` | Prometheus metric relabelings. |
 | monitoring.serviceMonitor.path | string | `"/metrics"` | Metrics path. |
-| monitoring.serviceMonitor.relabelings | list | `[]` | Prometheus relabelings. |
+| monitoring.serviceMonitor.relabelings | list | `[]` | Extra Prometheus relabelings, appended after the built-in one that maps the source pod's node name to a `node` label — the bundled dashboard groups GPUs by `node` (this is a DaemonSet, one pod per node, and the `device` PCI slot repeats across nodes). |
 | monitoring.serviceMonitor.scrapeTimeout | string | `"10s"` | Scrape timeout. |
 | nameOverride | string | `""` | Override the chart name used in the `app.kubernetes.io/name` label. |
 | nodeSelector | object | `{}` | Node selector for pod scheduling (templated). In mixed clusters, scope to GPU nodes — e.g. a Node Feature Discovery label like `feature.node.kubernetes.io/pci-0300_8086.present: "true"`. See the README. |

--- a/charts/drm-exporter/dashboards/drm-exporter.json
+++ b/charts/drm-exporter/dashboards/drm-exporter.json
@@ -44,6 +44,26 @@
         "regex": ""
       },
       {
+        "name": "node",
+        "type": "query",
+        "label": "Node",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "query": {
+          "qryType": 1,
+          "query": "label_values(drm_info, node)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "current": {},
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "allValue": ".*",
+        "sort": 1
+      },
+      {
         "name": "device",
         "type": "query",
         "label": "Device",
@@ -53,7 +73,7 @@
         },
         "query": {
           "qryType": 1,
-          "query": "label_values(drm_info, device)",
+          "query": "label_values(drm_info{node=~\"$node\"}, device)",
           "refId": "PrometheusVariableQueryEditor-VariableQuery"
         },
         "current": {},
@@ -118,7 +138,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "count(group by (device) (drm_info{device=~\"$device\"}))",
+          "expr": "count(group by (node, device) (drm_info{node=~\"$node\", device=~\"$device\"}))",
           "legendFormat": "",
           "range": true,
           "instant": false,
@@ -179,7 +199,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "max(drm_engine_utilization_ratio{device=~\"$device\"})",
+          "expr": "max(drm_engine_utilization_ratio{node=~\"$node\", device=~\"$device\"})",
           "legendFormat": "",
           "range": true,
           "instant": false,
@@ -216,7 +236,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_info{device=~\"$device\"}",
+          "expr": "drm_info{node=~\"$node\", device=~\"$device\"}",
           "legendFormat": "",
           "range": false,
           "instant": true,
@@ -297,8 +317,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_engine_utilization_ratio{device=~\"$device\"}",
-          "legendFormat": "{{device}} \u00b7 {{engine}}",
+          "expr": "drm_engine_utilization_ratio{node=~\"$node\", device=~\"$device\"}",
+          "legendFormat": "{{node}} \u00b7 {{device}} \u00b7 {{engine}}",
           "range": true,
           "instant": false,
           "format": "time_series",
@@ -359,8 +379,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_memory_used_bytes{device=~\"$device\"}",
-          "legendFormat": "{{device}} \u00b7 {{pool}}",
+          "expr": "drm_memory_used_bytes{node=~\"$node\", device=~\"$device\"}",
+          "legendFormat": "{{node}} \u00b7 {{device}} \u00b7 {{pool}}",
           "range": true,
           "instant": false,
           "format": "time_series",
@@ -421,8 +441,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_memory_used_bytes{device=~\"$device\"} / drm_memory_total_bytes{device=~\"$device\"}",
-          "legendFormat": "{{device}} \u00b7 {{pool}}",
+          "expr": "drm_memory_used_bytes{node=~\"$node\", device=~\"$device\"} / drm_memory_total_bytes{node=~\"$node\", device=~\"$device\"}",
+          "legendFormat": "{{node}} \u00b7 {{device}} \u00b7 {{pool}}",
           "range": true,
           "instant": false,
           "format": "time_series",
@@ -483,8 +503,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_frequency_hertz{device=~\"$device\"}",
-          "legendFormat": "{{device}} \u00b7 {{domain}} \u00b7 {{kind}}",
+          "expr": "drm_frequency_hertz{node=~\"$node\", device=~\"$device\"}",
+          "legendFormat": "{{node}} \u00b7 {{device}} \u00b7 {{domain}} \u00b7 {{kind}}",
           "range": true,
           "instant": false,
           "format": "time_series",
@@ -545,8 +565,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_power_watts{device=~\"$device\"}",
-          "legendFormat": "{{device}} \u00b7 {{domain}}",
+          "expr": "drm_power_watts{node=~\"$node\", device=~\"$device\"}",
+          "legendFormat": "{{node}} \u00b7 {{device}} \u00b7 {{domain}}",
           "range": true,
           "instant": false,
           "format": "time_series",
@@ -607,8 +627,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_temperature_celsius{device=~\"$device\"}",
-          "legendFormat": "{{device}} \u00b7 {{sensor}}",
+          "expr": "drm_temperature_celsius{node=~\"$node\", device=~\"$device\"}",
+          "legendFormat": "{{node}} \u00b7 {{device}} \u00b7 {{sensor}}",
           "range": true,
           "instant": false,
           "format": "time_series",
@@ -669,8 +689,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "drm_fan_speed_rpm{device=~\"$device\"}",
-          "legendFormat": "{{device}} \u00b7 {{fan}}",
+          "expr": "drm_fan_speed_rpm{node=~\"$node\", device=~\"$device\"}",
+          "legendFormat": "{{node}} \u00b7 {{device}} \u00b7 {{fan}}",
           "range": true,
           "instant": false,
           "format": "time_series",

--- a/charts/drm-exporter/templates/servicemonitor.tpl
+++ b/charts/drm-exporter/templates/servicemonitor.tpl
@@ -21,10 +21,12 @@ spec:
       path: {{ .Values.monitoring.serviceMonitor.path }}
       interval: {{ .Values.monitoring.serviceMonitor.interval }}
       scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout }}
-      {{- with .Values.monitoring.serviceMonitor.relabelings }}
       relabelings:
+        - sourceLabels: [__meta_kubernetes_pod_node_name]
+          targetLabel: node
+        {{- with .Values.monitoring.serviceMonitor.relabelings }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
       {{- with .Values.monitoring.serviceMonitor.metricRelabelings }}
       metricRelabelings:
         {{- toYaml . | nindent 8 }}

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -370,7 +370,7 @@
               "type": "string"
             },
             "relabelings": {
-              "description": "Prometheus relabelings.",
+              "description": "Extra Prometheus relabelings, appended after the built-in one that maps the source pod's node name to a `node` label — the bundled dashboard groups GPUs by `node` (this is a DaemonSet, one pod per node, and the `device` PCI slot repeats across nodes).",
               "items": {
                 "required": []
               },

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -180,7 +180,7 @@ monitoring:
     annotations: {}
     # -- Prometheus metric relabelings.
     metricRelabelings: []
-    # -- Prometheus relabelings.
+    # -- Extra Prometheus relabelings, appended after the built-in one that maps the source pod's node name to a `node` label — the bundled dashboard groups GPUs by `node` (this is a DaemonSet, one pod per node, and the `device` PCI slot repeats across nodes).
     relabelings: []
   dashboards:
     # -- Render the Grafana dashboard ConfigMap (for the kube-prometheus-stack sidecar or grafana-operator).


### PR DESCRIPTION
## Feedback

> it'd be nice if the dashboard could distinguish between nodes 🙂

The exporter runs as a DaemonSet (one pod per node), but the only GPU-identifying
label is `device` (the PCI slot), which **repeats across nodes** (e.g. every node's
iGPU is `0000:00:02.0`). With no node dimension, the dashboard overlaid different
nodes' GPUs into the same series/legend.

## Fix

Give the series a `node` label and teach the dashboard to use it:

- **ServiceMonitor** now relabels the scrape target's pod node name onto a `node`
  label (always, before any user-supplied relabelings).
- **Dashboard**: adds a `Node` template variable (multi-select + All); the `Device`
  list is scoped to the selected node(s) (`label_values(drm_info{node=~"$node"}, device)`);
  every panel filters by `node` + `device`; the GPU count groups by node+device; and
  legends are prefixed with `{{node}}`. The `GPU inventory` table picks up a `node`
  column for free.

Degrades gracefully: with `monitoring.serviceMonitor` disabled or a scrape that
doesn't add `node`, the `Node` var is empty and `$node` defaults to `.*`, so the
dashboard shows everything (today's behavior).

## Verification

`helm lint` clean; `helm unittest` 32/32; dashboard JSON re-parsed valid (vars now
`datasource, node, device`, 10 panels); ServiceMonitor renders the node relabeling;
chart README + values schema regenerated.
