### PR TITLE
feat(chart): polish the GPU dashboard

### DIFF
--- a/charts/drm-exporter/dashboards/drm-exporter.json
+++ b/charts/drm-exporter/dashboards/drm-exporter.json
@@ -175,14 +175,16 @@
                 "value": null
               }
             ]
-          }
+          },
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
       "options": {
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "max"
           ],
           "fields": "",
           "values": false
@@ -250,6 +252,7 @@
           "options": {
             "include": {
               "names": [
+                "node",
                 "device",
                 "vendor",
                 "model",
@@ -292,7 +295,9 @@
           },
           "color": {
             "mode": "palette-classic"
-          }
+          },
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
@@ -416,7 +421,9 @@
           },
           "color": {
             "mode": "palette-classic"
-          }
+          },
+          "min": 0,
+          "max": 1
         },
         "overrides": []
       },
@@ -598,10 +605,30 @@
             "fillOpacity": 10,
             "showPoints": "never",
             "spanNulls": false,
-            "axisPlacement": "auto"
+            "axisPlacement": "auto",
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
           },
           "color": {
             "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
           }
         },
         "overrides": []


### PR DESCRIPTION
## What

Polish pass on the bundled GPU dashboard (reviewed against the live instance).

- **Inventory table shows `node`** — the table's field filter still excluded it, so after the per-node change (#19) you couldn't tell which node a GPU row belonged to (and rows duplicated across nodes). Added `node` to the included fields.
- **Fixed 0–100% axes** — `Engine utilization`, `Memory utilization`, and `Peak engine busy` are ratios but auto-scaled, so a 3%→6% wiggle rendered like a cliff. Pinned `min: 0`, `max: 1`.
- **`Peak engine busy` reduces with `max`** (peak over the selected window) instead of `lastNotNull` — the panel said "Peak" but showed the current value.
- **Temperature threshold lines** — dashed reference lines at 80 °C and 95 °C for an at-a-glance read on whether anything is running hot.

Single-file change (the dashboard JSON, which ships verbatim). `helm lint` clean, `helm unittest` 32/32, JSON re-validated.
