### PR TITLE
fix(deps): update qmlib to qmassa main (799a63b)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,7 @@ dependencies = [
 [[package]]
 name = "qmlib"
 version = "2.2.0"
-source = "git+https://github.com/ulissesf/qmassa?rev=47e120d6f8a055926f9fa2347e52df49a41a7aba#47e120d6f8a055926f9fa2347e52df49a41a7aba"
+source = "git+https://github.com/ulissesf/qmassa?rev=799a63b6c86f0031193bc01bbfdeefe7d72d1cb9#799a63b6c86f0031193bc01bbfdeefe7d72d1cb9"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { version = "1", default-features = false, features = ["rt-multi-thread"
 # host, while the real collector is compiled in the Linux release image and CI.
 # qmlib is not published to crates.io, so it is pinned to an exact git revision.
 [target.'cfg(target_os = "linux")'.dependencies]
-qmlib = { git = "https://github.com/ulissesf/qmassa", rev = "47e120d6f8a055926f9fa2347e52df49a41a7aba" }
+qmlib = { git = "https://github.com/ulissesf/qmassa", rev = "799a63b6c86f0031193bc01bbfdeefe7d72d1cb9" }
 
 [profile.release]
 # A long-running daemon shipped in a distroless image: optimize for a small,


### PR DESCRIPTION
Bumps the `qmlib` git pin (the [qmassa](https://github.com/ulissesf/qmassa) GPU stats library) from `47e120d` to `799a63b` — the current tip of qmassa `main`.

## What changed upstream
[One commit](https://github.com/ulissesf/qmassa/compare/47e120d6f8a055926f9fa2347e52df49a41a7aba...799a63b6c86f0031193bc01bbfdeefe7d72d1cb9), touching a single file (`qmlib/src/drm_drivers/amdgpu.rs`):

> qmlib/amdgpu: report engine busyness only when sysfs files exist

It guards AMD engine-busyness reporting on the presence of the backing sysfs files, so AMD GPUs that don't expose them no longer surface spurious busyness readings. No public API change and no crate-version bump (still `2.2.0`), so drm-exporter's collector compiles and links against it unchanged.

## Verification
- **Host (macOS):** `cargo build --locked` (lockfile consistent with the manifest) + `mise run test` → 18/18 pass.
- **Linux (release image):** `mise run image` builds the full distroless/cc image clean — qmlib compiles at the new rev and the binary links against it (the gate that actually exercises the linux-only `qmlib` dependency).

Renovate doesn't track this git-rev pin (the org config only adds the helm-docs post-upgrade step), so this is a manual bump.