### PR TITLE
build(deps): source qmlib from crates.io

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,26 +1,12 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
-  packageRules: [
-    {
-      matchManagers: ["cargo"],
-      matchDatasources: ["git-refs", "git-tags"],
-      postUpgradeTasks: {
-        commands: ["cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --package {{{depName}}}"],
-        fileFilters: ["Cargo.lock"],
-        executionMode: "update",
-      },
-    },
-  ],
   postUpgradeTasks: {
     commands: [
       "helm-docs --chart-search-root=charts --log-level=warn",
       "helm-schema --chart-search-root charts/drm-exporter --skip-auto-generation required,additionalProperties --append-newline",
     ],
-    fileFilters: [
-      "charts/drm-exporter/README.md",
-      "charts/drm-exporter/values.schema.json",
-    ],
+    fileFilters: ["charts/drm-exporter/README.md", "charts/drm-exporter/values.schema.json"],
     executionMode: "branch",
   },
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -914,7 +914,8 @@ dependencies = [
 [[package]]
 name = "qmlib"
 version = "2.2.1"
-source = "git+https://github.com/ulissesf/qmassa?rev=4b0dbec1fc8c1fa76be8b308c4d967e87c69dca8#4b0dbec1fc8c1fa76be8b308c4d967e87c69dca8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b1415bb603d6e02aeb06a081c668fd79149c782c11ded718b3eeae6fc9eda5"
 dependencies = [
  "anyhow",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,11 @@ tokio = { version = "1", default-features = false, features = ["rt-multi-thread"
 # builds on Linux. Gating it to the Linux target keeps the platform-independent
 # core (the sample model + the metric recorder) compiling and testable on any
 # host, while the real collector is compiled in the Linux release image and CI.
-# qmlib is not published to crates.io, so it is pinned to an exact git revision.
+# Versioned like the rest of the org's crates (caret major.minor, cf. kopiur's
+# kube = "3.1"); the committed Cargo.lock pins the exact build. Was git-rev
+# pinned until qmlib was published to crates.io.
 [target.'cfg(target_os = "linux")'.dependencies]
-qmlib = { git = "https://github.com/ulissesf/qmassa", rev = "4b0dbec1fc8c1fa76be8b308c4d967e87c69dca8" }
+qmlib = "2.2"
 
 [profile.release]
 # A long-running daemon shipped in a distroless image: optimize for a small,


### PR DESCRIPTION
## What

Source `qmlib` from crates.io instead of a git revision, versioned the same way as the rest of the org's crates.

```diff
-qmlib = { git = "https://github.com/ulissesf/qmassa", rev = "4b0dbec…" }
+qmlib = "2.2"
```

`qmlib` (qmassa's GPU stats library) is now **published to crates.io** by its author (`ulissesf`, repository `github.com/ulissesf/qmassa`). The pinned rev `4b0dbec` *is* tag `qmlib-v2.2.1` = published `2.2.1`, so this is byte-identical code: `Cargo.lock` only swaps qmlib's `source` git→registry (+checksum); version and all transitive deps are unchanged (`log` stays `0.4.33`).

**Versioning matches kopiur's crates** — caret major.minor (`qmlib = "2.2"`, cf. `kube = "3.1"`, `reqwest = "0.12"`), with the committed `Cargo.lock` pinning the exact build (2.2.1). This is the org-consistent style; drm-exporter is a binary, so the lock is the source of truth for reproducibility and the manifest only floats within the minor.

## Also: drop the now-dead cargo `postUpgradeTask`

`.renovaterc.json5` carried a `matchDatasources: [git-refs, git-tags]` cargo `postUpgradeTask` whose only purpose was regenerating `Cargo.lock` for qmlib's git rev. qmlib was the **only** git cargo dependency, so once it's on the registry that rule can never match again — removed. (It couldn't have done its job regardless: a post-upgrade task runs *after* the built-in cargo updater and can't clear an artifact error the built-in already recorded.) The chart-docs `postUpgradeTask` (helm-docs / helm-schema) is untouched.

Net Renovate effect: qmlib tracked as datasource `crate`, so the built-in cargo updater resolves transitive bumps on its own — no more manual `cargo update -p qmlib` + lockfile commits.

## Verify

- `cargo check --locked` passes; `qmlib = "2.2"` resolves to the already-locked `2.2.1` with no `Cargo.lock` change.
- `Cargo.lock`: qmlib → `registry+…crates.io-index` `2.2.1`; **zero** git sources remain.
- The Linux/qmlib compile is exercised by the Rust Tests / Lint / Coverage jobs (Linux runners).
