### PR TITLE
feat!: adopt the /healthz + /readyz pair and a dual-stack default bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ All series are gauges prefixed `drm_`, with a `device` label (the PCI slot, e.g.
 | `drm_fan_speed_rpm`                                | `fan`                                                                 | Fan speed                                                        |
 
 A section is simply omitted for a device/driver that does not expose it (e.g.
-no `drm_power_watts` where power is unavailable). `GET /health` returns `OK` for
+no `drm_power_watts` where power is unavailable). `GET /healthz` / `GET /readyz` return `OK` for
 liveness probes; metrics are served on `GET /metrics` (and any other path).
 
 Metrics are instrumented on the OpenTelemetry API and exposed through

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -5,7 +5,7 @@
 A Prometheus exporter for Intel and AMD GPU metrics — utilization, memory,
 frequency, power, and thermals — deployed as a per-node DaemonSet. It reads the
 kernel DRM interfaces via [qmlib](https://github.com/ulissesf/qmassa) and serves
-metrics on `/metrics`, with a `/health` endpoint for probes.
+metrics on `/metrics`, with `/healthz` and `/readyz` endpoints for probes.
 
 **Homepage:** <https://github.com/home-operations/drm-exporter>
 
@@ -126,7 +126,7 @@ Kubernetes: `>=1.34.0-0`
 | image.tag | string | `""` | Overrides the image tag; defaults to the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries. |
 | initContainers | list | `[]` | Additional init containers (templated). |
-| livenessProbe | object | `{"httpGet":{"path":"/health","port":"metrics"},"initialDelaySeconds":5,"periodSeconds":20}` | Liveness probe. `/health` is the exporter's lightweight readiness endpoint (returns `OK`). |
+| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"metrics"},"initialDelaySeconds":5,"periodSeconds":20}` | Liveness probe. Targets /healthz (returns `OK`; /readyz and the legacy /health are aliases). |
 | monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap (templated). |
 | monitoring.dashboards.enabled | bool | `false` | Render the Grafana dashboard ConfigMap (for the kube-prometheus-stack sidecar or grafana-operator). |
 | monitoring.dashboards.grafanaOperator.allowCrossNamespaceImport | bool | `true` | Allow a Grafana in any namespace to import this GrafanaDashboard. |
@@ -150,7 +150,7 @@ Kubernetes: `>=1.34.0-0`
 | podLabels | object | `{}` | Labels added to the pod. |
 | podSecurityContext | object | `{"runAsGroup":0,"runAsNonRoot":false,"runAsUser":0,"seccompProfile":{"type":"RuntimeDefault"}}` | Pod-level securityContext. The exporter runs as root by default because GPU telemetry needs MSR access (Intel package power) and the perf PMU on locked-down kernels; see `securityContext` for the (narrow) capability set. Override to run unprivileged where your nodes permit it. |
 | priorityClassName | string | `""` | PriorityClass for the pod (templated); empty uses the cluster default. |
-| readinessProbe | object | `{"httpGet":{"path":"/health","port":"metrics"},"initialDelaySeconds":2,"periodSeconds":10}` | Readiness probe. |
+| readinessProbe | object | `{"httpGet":{"path":"/readyz","port":"metrics"},"initialDelaySeconds":2,"periodSeconds":10}` | Readiness probe. |
 | resources | object | `{}` | Exporter container resource requests/limits. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["PERFMON","SYS_RAWIO"],"drop":["ALL"]},"privileged":false,"readOnlyRootFilesystem":true}` | Exporter container securityContext. Drops ALL capabilities, then adds only what GPU telemetry needs: PERFMON (Intel i915/xe engine utilization via the perf PMU) and SYS_RAWIO (Intel iGPU package temperature + the RAPL power fallback via /dev/cpu/*/msr, which needs the host msr kernel module — absent on Talos, so drop SYS_RAWIO there). AMD and all sysfs-based stats need neither. Read-only root filesystem, no privilege escalation, not privileged. |
 | service.annotations | object | `{}` | Service annotations. |

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -126,7 +126,7 @@ Kubernetes: `>=1.34.0-0`
 | image.tag | string | `""` | Overrides the image tag; defaults to the chart appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries. |
 | initContainers | list | `[]` | Additional init containers (templated). |
-| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"metrics"},"initialDelaySeconds":5,"periodSeconds":20}` | Liveness probe. Targets /healthz (returns `OK`; /readyz and the legacy /health are aliases). |
+| livenessProbe | object | `{"httpGet":{"path":"/healthz","port":"metrics"},"initialDelaySeconds":5,"periodSeconds":20}` | Liveness probe. Targets /healthz (returns `OK`; /readyz is an alias). |
 | monitoring.dashboards.annotations | object | `{}` | Annotations added to the dashboard ConfigMap (templated). |
 | monitoring.dashboards.enabled | bool | `false` | Render the Grafana dashboard ConfigMap (for the kube-prometheus-stack sidecar or grafana-operator). |
 | monitoring.dashboards.grafanaOperator.allowCrossNamespaceImport | bool | `true` | Allow a Grafana in any namespace to import this GrafanaDashboard. |

--- a/charts/drm-exporter/README.md.gotmpl
+++ b/charts/drm-exporter/README.md.gotmpl
@@ -7,7 +7,7 @@
 A Prometheus exporter for Intel and AMD GPU metrics — utilization, memory,
 frequency, power, and thermals — deployed as a per-node DaemonSet. It reads the
 kernel DRM interfaces via [qmlib](https://github.com/ulissesf/qmassa) and serves
-metrics on `/metrics`, with a `/health` endpoint for probes.
+metrics on `/metrics`, with `/healthz` and `/readyz` endpoints for probes.
 
 {{ template "chart.homepageLine" . }}
 

--- a/charts/drm-exporter/tests/daemonset_test.yaml
+++ b/charts/drm-exporter/tests/daemonset_test.yaml
@@ -83,7 +83,7 @@ tests:
             name: DRM_EXPORTER_DEVICES
             value: "0000:03:00.0,0000:00:02.0"
 
-  - it: exposes the metrics port and probes it on /health
+  - it: exposes the metrics port and probes it on /healthz + /readyz
     template: daemonset.tpl
     asserts:
       - contains:
@@ -94,10 +94,10 @@ tests:
             protocol: TCP
       - equal:
           path: spec.template.spec.containers[0].livenessProbe.httpGet.path
-          value: /health
+          value: /healthz
       - equal:
           path: spec.template.spec.containers[0].readinessProbe.httpGet.path
-          value: /health
+          value: /readyz
 
   - it: grants only the PERFMON and SYS_RAWIO capabilities
     template: daemonset.tpl

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -225,7 +225,7 @@
       "type": "array"
     },
     "livenessProbe": {
-      "description": "Liveness probe. Targets /healthz (returns `OK`; /readyz and the legacy /health are aliases).",
+      "description": "Liveness probe. Targets /healthz (returns `OK`; /readyz is an alias).",
       "properties": {
         "httpGet": {
           "properties": {

--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -225,12 +225,12 @@
       "type": "array"
     },
     "livenessProbe": {
-      "description": "Liveness probe. `/health` is the exporter's lightweight readiness endpoint (returns `OK`).",
+      "description": "Liveness probe. Targets /healthz (returns `OK`; /readyz and the legacy /health are aliases).",
       "properties": {
         "httpGet": {
           "properties": {
             "path": {
-              "default": "/health",
+              "default": "/healthz",
               "title": "path",
               "type": "string"
             },
@@ -464,7 +464,7 @@
         "httpGet": {
           "properties": {
             "path": {
-              "default": "/health",
+              "default": "/readyz",
               "title": "path",
               "type": "string"
             },

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -143,7 +143,7 @@ securityContext:
       - PERFMON
       - SYS_RAWIO
 
-# -- Liveness probe. Targets /healthz (returns `OK`; /readyz and the legacy /health are aliases).
+# -- Liveness probe. Targets /healthz (returns `OK`; /readyz is an alias).
 livenessProbe:
   httpGet:
     path: /healthz

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -143,17 +143,17 @@ securityContext:
       - PERFMON
       - SYS_RAWIO
 
-# -- Liveness probe. `/health` is the exporter's lightweight readiness endpoint (returns `OK`).
+# -- Liveness probe. Targets /healthz (returns `OK`; /readyz and the legacy /health are aliases).
 livenessProbe:
   httpGet:
-    path: /health
+    path: /healthz
     port: metrics
   initialDelaySeconds: 5
   periodSeconds: 20
 # -- Readiness probe.
 readinessProbe:
   httpGet:
-    path: /health
+    path: /readyz
     port: metrics
   initialDelaySeconds: 2
   periodSeconds: 10

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,8 +22,10 @@ pub struct Args {
     )]
     pub devices: Vec<String>,
 
-    /// Address the metrics HTTP server binds to.
-    #[arg(short, long, default_value = "0.0.0.0", env = "DRM_EXPORTER_ADDRESS")]
+    /// Address the metrics HTTP server binds to. The default `::` is the
+    /// unspecified address: on Linux it accepts IPv4 and IPv6 alike
+    /// (dual-stack), where `0.0.0.0` would be IPv4-only.
+    #[arg(short, long, default_value = "::", env = "DRM_EXPORTER_ADDRESS")]
     pub address: IpAddr,
 
     /// Port the metrics HTTP server listens on.
@@ -70,7 +72,7 @@ mod tests {
     #[test]
     fn defaults_match_the_documented_values() {
         let args = Args::parse_from(["drm-exporter"]);
-        assert_eq!(args.address.to_string(), "0.0.0.0");
+        assert_eq!(args.address.to_string(), "::");
         assert_eq!(args.port, 8081);
         assert_eq!(args.interval_seconds, 5);
         assert!(args.devices.is_empty());

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Discovers DRM GPUs through `qmlib`, then on a fixed interval refreshes their
 //! stats and records them as OpenTelemetry gauges, exposed on a Prometheus
-//! `/metrics` endpoint (plus `/health`). See [`metrics`] for the exported series,
+//! `/metrics` endpoint (plus `/healthz` and `/readyz`). See [`metrics`] for the exported series,
 //! [`telemetry`] for the OTel→Prometheus wiring, and [`cli`] for the flags.
 
 mod cli;
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
 
     info!(version = VERSION, "starting drm-exporter");
 
-    // Build the OTel meter + Prometheus exporter, then serve /metrics + /health
+    // Build the OTel meter + Prometheus exporter, then serve /metrics + health
     // on a background thread (the refresh loop owns the main thread).
     let telemetry = Telemetry::new().context("initializing metrics")?;
     let metrics = Metrics::new(telemetry.meter());
@@ -75,11 +75,14 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-/// Serve the Prometheus exposition on every request except `/health`, a
-/// lightweight liveness endpoint that returns `OK`. Runs until the process exits.
+/// Serve the Prometheus exposition on every request except the health
+/// endpoints, which return `OK`. `/healthz` (liveness) and `/readyz`
+/// (readiness) follow the org pair standard — aliases here, the exporter has
+/// no serving condition beyond being up; `/health` is kept for backward
+/// compatibility. Runs until the process exits.
 fn serve(server: tiny_http::Server, registry: &prometheus::Registry) {
     for request in server.incoming_requests() {
-        let response = if request.url() == "/health" {
+        let response = if matches!(request.url(), "/healthz" | "/readyz" | "/health") {
             tiny_http::Response::from_string("OK")
         } else {
             let header = tiny_http::Header::from_bytes(

--- a/src/main.rs
+++ b/src/main.rs
@@ -78,11 +78,10 @@ fn main() -> Result<()> {
 /// Serve the Prometheus exposition on every request except the health
 /// endpoints, which return `OK`. `/healthz` (liveness) and `/readyz`
 /// (readiness) follow the org pair standard — aliases here, the exporter has
-/// no serving condition beyond being up; `/health` is kept for backward
-/// compatibility. Runs until the process exits.
+/// no serving condition beyond being up. Runs until the process exits.
 fn serve(server: tiny_http::Server, registry: &prometheus::Registry) {
     for request in server.incoming_requests() {
-        let response = if matches!(request.url(), "/healthz" | "/readyz" | "/health") {
+        let response = if matches!(request.url(), "/healthz" | "/readyz") {
             tiny_http::Response::from_string("OK")
         } else {
             let header = tiny_http::Header::from_bytes(


### PR DESCRIPTION
Rollout PR (exporter tier) of the org metrics/health standard.

- **`/healthz` (liveness) + `/readyz` (readiness)** served alongside `/metrics` on the single 8081 listener (exporter tier: one port, no disable). Aliases here — the exporter has no serving condition beyond being up. **`/health` is removed** (no legacy path — per review); anything probing it must move to the pair.
- Chart probes target the new paths (liveness → `/healthz`, readiness → `/readyz`).
- **Bind rule:** default address `0.0.0.0` → `::` (the unspecified address — dual-stack on Linux, so IPv4 *and* IPv6 clusters work; `0.0.0.0` was IPv4-only). Hosts with IPv6 disabled at the kernel (`ipv6.disable=1`) can set `DRM_EXPORTER_ADDRESS=0.0.0.0`.

Verified: `cargo test` (18 passed; core is macOS-testable by design), `clippy` clean, `fmt-check` clean, `helm lint`, `helm unittest` 32/32, helm-docs regenerated.

Remaining rollout: tuppr / litellm-operator / miroir (rule-2 co-host consolidation).