### PR TITLE
chore: add .editorconfig from the org standard

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,42 @@
+; https://editorconfig.org/
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+indent_size = 2
+trim_trailing_whitespace = false
+
+[Dockerfile]
+indent_size = 4
+
+[*.py]
+indent_size = 4
+
+[{*.sh,*.bash}]
+indent_size = 4
+
+[{*.just,*.justfile}]
+indent_size = 4
+
+[{Makefile,*.mk}]
+indent_style = tab
+indent_size = 4
+
+[{*.go,go.mod,go.sum}]
+indent_style = tab
+indent_size = 4
+
+[*.rs]
+indent_size = 4
+
+[.gitmodules]
+indent_style = tab
+indent_size = 4


### PR DESCRIPTION
drm-exporter was the only active repo in the org without a `.editorconfig`. This adds one copied verbatim from `home-operations/.github`, so editors pick up the shared indent conventions (2-space default, 4 for shell/python/Dockerfile, tabs for Go/Make).

No existing files are reformatted. The CI format gate here is `cargo fmt --check` (Rust), which does not read `.editorconfig`, so this cannot affect CI.