### PR TITLE
fix(helm): stamp Chart.yaml version on release

### DIFF
--- a/charts/drm-exporter/Chart.yaml
+++ b/charts/drm-exporter/Chart.yaml
@@ -6,10 +6,10 @@ type: application
 # Minimum supported Kubernetes is 1.34, matching the DRA `resource.k8s.io/v1` API
 # (GA in 1.34) used by the optional ResourceClaimTemplate.
 kubeVersion: ">=1.34.0-0"
-# version + appVersion are overridden at package time: version from the release
-# tag, appVersion from the same tag (the chart deploys the exporter's own image).
-version: 0.0.0
-appVersion: "0.0.0"
+# release-please stamps both on release (the release workflow also re-stamps them
+# from the tag at package time); keeping the repo copy current stops it going stale.
+version: 0.3.1 # x-release-please-version
+appVersion: "0.3.1" # x-release-please-version
 home: https://github.com/home-operations/drm-exporter
 sources:
   - https://github.com/home-operations/drm-exporter

--- a/charts/drm-exporter/README.md
+++ b/charts/drm-exporter/README.md
@@ -1,6 +1,8 @@
 # drm-exporter
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.3.1&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.3.1&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 A Prometheus exporter for Intel and AMD GPU metrics — utilization, memory,
 frequency, power, and thermals — deployed as a per-node DaemonSet. It reads the

--- a/charts/drm-exporter/README.md.gotmpl
+++ b/charts/drm-exporter/README.md.gotmpl
@@ -2,7 +2,15 @@
 
 {{ template "chart.deprecationWarning" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its updater replaces only the first semver on an annotated
+line and would swallow a `-color` suffix as a prerelease, so each version badge
+uses the static/v1 query form (version followed by `&`), keeps the version out
+of its alt text, and carries its own annotation. Keeps the committed README in
+sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 A Prometheus exporter for Intel and AMD GPU metrics — utilization, memory,
 frequency, power, and thermals — deployed as a per-node DaemonSet. It reads the

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,11 @@
       "include-component-in-tag": false,
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
-      "always-update": true
+      "always-update": true,
+      "extra-files": [
+        { "type": "generic", "path": "charts/drm-exporter/Chart.yaml" },
+        "charts/drm-exporter/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Ports home-operations/tuppr#414 + home-operations/tuppr#415 to this repo (chart-only; no Rust changes).

## What

The in-repo chart carried a `0.0.0` placeholder for both `version` and `appVersion`, so the committed `Chart.yaml` and the generated chart README never matched a real release. release-please now stamps both (current release `0.3.1`). The release workflow still packages with `--version`/`--app-version` from the tag, so the published chart is unchanged; this only keeps the repo copy from going stale.

## Why the typed generic updater

`Chart.yaml` is registered as `{ "type": "generic", "path": ... }` rather than a bare string path. A plain path with a `.yaml` extension makes release-please pick its YAML updater, which re-serializes the document (stripping every comment in `Chart.yaml`) and misses `appVersion` entirely. The generic updater does an annotation-driven in-place replacement, so the comments survive and both annotated lines get stamped.

## Badge consequence

The chart README badges are now hand-rolled in `README.md.gotmpl` instead of `{{ template "chart.badgesSection" . }}`: the generic updater replaces only the first semver on an annotated line, and shields.io's `/badge/` form would let it swallow the `-informational` colour suffix as a prerelease. Each version badge therefore uses the `static/v1` query form (version followed by `&`), keeps the version out of its alt text, and carries its own `<!-- x-release-please-version -->` annotation. The comment in the template documents that constraint.

## Tests

No chart unit test changes were needed. `charts/drm-exporter/tests/daemonset_test.yaml` already asserts the image tag by overriding `chart.appVersion: 1.2.3` rather than matching the placeholder, so it is version-independent already. The only other `0.0.0`-looking matches in the chart are the `0.0.0.0` metrics bind address, which is unrelated.

Cargo.toml / Cargo.lock are untouched: release-please (`release-type: simple`) does not stamp them here, and nothing in this change reaches Rust code.

## Verification

- `mise run helm-lint` - pass (`1 chart(s) linted, 0 chart(s) failed`; pre-existing `icon is recommended` info only)
- `mise run helm-test` (`helm unittest`) - pass: 7 suites, 32 tests, 0 failures
- `mise run helm-docs` then `mise run helm-docs-check` - pass, exit 0, no diff (README regenerated with the new badges and `0.3.1`; `values.schema.json` unchanged)
- `jq -e . release-please-config.json` - valid JSON; the shared lefthook `format-json`/`format-yaml` hooks ran clean on commit
- Rust gates deliberately not run: no Rust file is touched
