### PR TITLE
ci: skip release-please version-bump PRs in checks

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -30,6 +30,9 @@ env:
 
 jobs:
   coverage:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Coverage
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -29,6 +29,9 @@ env:
 
 jobs:
   rust-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Rust Lint
     runs-on: ubuntu-24.04
     permissions:
@@ -63,6 +66,9 @@ jobs:
         run: mise run clippy
 
   helm-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Helm Lint
     runs-on: ubuntu-24.04
     permissions:
@@ -86,6 +92,9 @@ jobs:
         run: mise run helm-docs-check
 
   cargo-audit:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Cargo Audit
     runs-on: ubuntu-24.04
     continue-on-error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,6 +32,9 @@ env:
 
 jobs:
   rust-test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Rust Tests
     runs-on: ubuntu-24.04
     permissions:
@@ -63,6 +66,9 @@ jobs:
         run: mise run test
 
   helm-test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Helm Unit Tests
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Guards the check jobs so only **genuine release-please PRs** are skipped, using a signal a contributor can't forge:

```yaml
if: >-
  ${{ !(startsWith(github.head_ref, 'release-please--')
  && github.event.pull_request.head.repo.full_name == github.repository) }}
```

The earlier `startsWith(github.head_ref, ...)`-only form was unsafe: `head_ref` is the PR's source branch name, which anyone can set - including from a fork - so a PR from a `release-please--*` branch would skip every check. Requiring the PR head repo to be this repo means fork PRs (the realistic path for outside contributors) always run the full suite. Ordinary PRs, pushes to `main`, and `workflow_dispatch` are unaffected.

Part of an org-wide CI conformity / minutes pass.
