### PR TITLE
fix(chart): keep the env example out of the extraEnv schema description

### DIFF
--- a/charts/drm-exporter/values.schema.json
+++ b/charts/drm-exporter/values.schema.json
@@ -126,7 +126,7 @@
       "type": "array"
     },
     "extraEnv": {
-      "description": "  TZ: UTC\nExtra environment variables for the container, as a raw list (templated).",
+      "description": "Extra environment variables for the container, as a raw list (templated).",
       "items": {
         "required": []
       },

--- a/charts/drm-exporter/values.yaml
+++ b/charts/drm-exporter/values.yaml
@@ -42,6 +42,7 @@ config:
 # -- Extra environment variables for the container, as a map (templated).
 env: {}
 #   TZ: UTC
+
 # -- Extra environment variables for the container, as a raw list (templated).
 extraEnv: []
 # -- Sources of environment variables for the container (templated).


### PR DESCRIPTION
Same fix as home-operations/gatus-sidecar#170: helm-schema attaches a commented example block to the *next* key's description in `values.schema.json`, which surfaces as hover docs in editors consuming the schema. One instance here: the `env` example ("TZ: UTC") leaked into `extraEnv`.

A blank line after the example block stops helm-schema from carrying it forward. Verified with a schema-wide scan (no leaked descriptions remain); chart README is unchanged, `helm lint` clean.
