### PR TITLE
fix(deps): update h2 to 0.4.19 for RUSTSEC-2026-0258

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",


### PR DESCRIPTION
## Summary

`cargo deny check` (the CI `cargo-audit` job) fails on [RUSTSEC-2026-0258](https://rustsec.org/advisories/RUSTSEC-2026-0258): `h2 0.4.15` accepts and queues empty DATA frames without limit, leading to unbounded memory use or a length-overflow panic if streams are not drained. Low severity; patched in `h2 >= 0.4.16`.

`h2` is a transitive dependency via `opentelemetry-otlp -> tonic -> hyper`, so it only affects the optional OTLP push path. This is a lockfile-only bump (`cargo update -p h2`, 0.4.15 -> 0.4.19); no other packages change and it stays within the 1.97 MSRV.

## Verification

- `mise run audit`: advisories ok, bans ok, licenses ok, sources ok
- `mise run build`: ok
- `mise run test`: 18 passed